### PR TITLE
Fixed Project describe "name" field  error in swagger.yaml

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -765,7 +765,7 @@ definitions:
         type: integer
         format: int32
         description: The owner ID of the project always means the creator of the project.
-      name:
+      project_name:
         type: string
         description: The name of the project.
       creation_time:


### PR DESCRIPTION
The "name" field of Project's properties in swagger.yaml,
but "POST" Project API use parameter "project_name".