### PR TITLE
support /v1/search API and configurable cache interval

### DIFF
--- a/Deploy/config/nginx/nginx.https.conf
+++ b/Deploy/config/nginx/nginx.https.conf
@@ -42,6 +42,19 @@ http {
     # required to avoid HTTP 411: see Issue #1486 (https://github.com/docker/docker/issues/1486)
     chunked_transfer_encoding on;
 
+    location = /v1/search {
+      proxy_pass http://ui/v1/search;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      proxy_buffering off;
+      proxy_request_buffering off;
+    }
+
     location / {
       proxy_pass http://ui/;
       proxy_set_header Host $http_host;

--- a/Deploy/docker-compose.yml
+++ b/Deploy/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 1514:514
   registry:
-    image: library/registry:2.4.0
+    image: library/registry:2.5.0
     restart: always
     volumes:
       - /data/registry:/storage

--- a/Deploy/harbor.cfg
+++ b/Deploy/harbor.cfg
@@ -16,6 +16,9 @@ email_password = abc
 email_from = admin <sample_admin@mydomain.com>
 email_ssl = false
 
+## The expiration interval of repository list cache, in second
+cache_interval = 28800
+
 ##The password of Harbor admin, change this before any production use.
 harbor_admin_password = Harbor12345
 

--- a/Deploy/prepare
+++ b/Deploy/prepare
@@ -32,6 +32,7 @@ email_username = rcp.get("configuration", "email_username")
 email_password = rcp.get("configuration", "email_password")
 email_from = rcp.get("configuration", "email_from")
 email_ssl = rcp.get("configuration", "email_ssl")
+cache_interval = rcp.get("configuration", "cache_interval")
 harbor_admin_password = rcp.get("configuration", "harbor_admin_password")
 auth_mode = rcp.get("configuration", "auth_mode")
 ldap_url = rcp.get("configuration", "ldap_url")
@@ -113,6 +114,7 @@ render(os.path.join(templates_dir, "ui", "app.conf"),
         email_password=email_password,
         email_from=email_from,
         email_ssl=email_ssl,
+        cache_interval=cache_interval,
         ui_url=ui_url)
 
 render(os.path.join(templates_dir, "registry", "config.yml"),

--- a/Deploy/templates/ui/app.conf
+++ b/Deploy/templates/ui/app.conf
@@ -15,3 +15,6 @@ username = $email_username
 password = $email_password
 from = $email_from
 ssl = $email_ssl
+
+[cache]
+interval = $cache_interval

--- a/api/project.go
+++ b/api/project.go
@@ -41,7 +41,7 @@ type projectReq struct {
 }
 
 const projectNameMaxLen int = 30
-const projectNameMinLen int = 4
+const projectNameMinLen int = 1
 const dupProjectPattern = `Duplicate entry '\w+' for key 'name'`
 
 // Prepare validates the URL and the user
@@ -292,7 +292,7 @@ func isProjectAdmin(userID int, pid int64) bool {
 func validateProjectReq(req projectReq) error {
 	pn := req.ProjectName
 	if isIllegalLength(req.ProjectName, projectNameMinLen, projectNameMaxLen) {
-		return fmt.Errorf("Project name is illegal in length. (greater than 4 or less than 30)")
+		return fmt.Errorf("Project name is illegal in length. (greater than 0 or less than 31)")
 	}
 	validProjectName := regexp.MustCompile(`^[a-z0-9](?:-*[a-z0-9])*(?:[._][a-z0-9](?:-*[a-z0-9])*)*$`)
 	legal := validProjectName.MatchString(pn)

--- a/service/cache/cache.go
+++ b/service/cache/cache.go
@@ -16,13 +16,16 @@
 package cache
 
 import (
+	"fmt"
 	"os"
 	"time"
 
+	_ "github.com/vmware/harbor/controllers"	// it initializes beego.AppConfig
 	"github.com/vmware/harbor/utils/log"
 	"github.com/vmware/harbor/utils/registry"
 	"github.com/vmware/harbor/utils/registry/auth"
 
+	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/cache"
 )
 
@@ -31,13 +34,16 @@ var (
 	Cache    cache.Cache
 	endpoint string
 	username string
+	interval int
 )
 
 const catalogKey string = "catalog"
 
 func init() {
 	var err error
-	Cache, err = cache.NewCache("memory", `{"interval":720}`)
+	interval = beego.AppConfig.DefaultInt("cache::interval", 720)
+	log.Infof("cache::interval is %d", interval)
+	Cache, err = cache.NewCache("memory", fmt.Sprintf(`{"interval": %d}`, interval))
 	if err != nil {
 		log.Errorf("Failed to initialize cache, error:%v", err)
 	}
@@ -86,7 +92,7 @@ func RefreshCatalogCache() error {
 		}
 	*/
 
-	Cache.Put(catalogKey, rs, 600*time.Second)
+	Cache.Put(catalogKey, rs, time.Duration(interval) * time.Second)
 	return nil
 }
 

--- a/service/notification.go
+++ b/service/notification.go
@@ -34,7 +34,7 @@ type NotificationHandler struct {
 	beego.Controller
 }
 
-const manifestPattern = `^application/vnd.docker.distribution.manifest.v\d\+json`
+const manifestPattern = `^application/vnd.docker.distribution.manifest.v\d`
 
 // Post handles POST request, and records audit log or refreshes cache based on event.
 func (n *NotificationHandler) Post() {
@@ -94,8 +94,8 @@ func filterEvents(notification *models.Notification) ([]*models.Event, error) {
 	events := []*models.Event{}
 
 	for _, event := range notification.Events {
-		log.Debugf("receive an event: ID-%s, target-%s:%s, digest-%s, action-%s", event.ID, event.Target.Repository, event.Target.Tag,
-			event.Target.Digest, event.Action)
+		log.Debugf("receive an event: ID-%s, target-%s:%s, digest-%s, action-%s, mediaType-%s, userAgent-%s", event.ID, event.Target.Repository, event.Target.Tag,
+			event.Target.Digest, event.Action, event.Target.MediaType, event.Request.UserAgent)
 
 		isManifest, err := regexp.MatchString(manifestPattern, event.Target.MediaType)
 		if err != nil {

--- a/ui/router.go
+++ b/ui/router.go
@@ -56,6 +56,7 @@ func initRouters() {
 	beego.Router("/sign_in", &controllers.SignInController{})
 
 	//API:
+	beego.Router("/v1/search", &api.SearchAPI{})
 	beego.Router("/api/search", &api.SearchAPI{})
 	beego.Router("/api/projects/:pid([0-9]+)/members/?:mid", &api.ProjectMemberAPI{})
 	beego.Router("/api/projects/", &api.ProjectAPI{}, "get:List")


### PR DESCRIPTION
(1) `docker search` uses /v1/search, this patch enables this function.
(2) the expiration interval of repository list cache is hardcoded to
    720s, this patch makes it configurable and 8 hours in configuration
    file by default.
(3) upgrade docker-registry to v2.5 due to a bug in garbage-collect,
    see https://github.com/docker/distribution/issues/1640
(4) relax minimal length of project name to one character, kindly allow
    users to shoot their feet.
(5) relax manifest pattern for Docker 1.7.1, it sends media type
    application/vnd.docker.distribution.manifest.v1+prettyjws.