### PR TITLE
Expire time of cached token

### DIFF
--- a/Deploy/templates/ui/env
+++ b/Deploy/templates/ui/env
@@ -17,6 +17,7 @@ LDAP_FILTER=$ldap_filter
 LDAP_UID=$ldap_uid
 LDAP_SCOPE=$ldap_scope
 UI_SECRET=$ui_secret
+SECRET_KEY=$secret_key
 SELF_REGISTRATION=$self_registration
 USE_COMPRESSED_JS=$use_compressed_js
 LOG_LEVEL=debug


### PR DESCRIPTION
1. record the local time when token is issued to avoid the mismatch of time for client and registry 2.recover the env variable