### PR TITLE
Resize the defaultPageSize in api/base.go

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	defaultPageSize int64 = 10
+	defaultPageSize int64 = 100
 	maxPageSize     int64 = 100
 )
 


### PR DESCRIPTION
The defaultPageSize now could case the lack of initial replication if the project's repository is more than 10,So I resize it from 10 to 100.