### PR TITLE
Improves namespace validation for Docker Notary integration

### DIFF
--- a/src/ui/service/token/authutils.go
+++ b/src/ui/service/token/authutils.go
@@ -105,8 +105,15 @@ func FilterAccess(username string, a *token.ResourceActions) {
 	//clear action list to assign to new acess element after perm check.
 	a.Actions = []string{}
 	if a.Type == "repository" {
-		if strings.Contains(a.Name, "/") { //Only check the permission when the requested image has a namespace, i.e. project
-			projectName := a.Name[0:strings.LastIndex(a.Name, "/")]
+		repoSplit := strings.Split(a.Name, "/")
+		repoLength := len(repoSplit)
+		if repoLength > 0 { //Only check the permission when the requested image has a namespace, i.e. project
+			var projectName string
+			if repoLength > 2 { //If the repo contains more than 1 separation (as privateregistry.local/library/alpine) consider the second item from array (library)
+				projectName = repoSplit[1]
+			} else { // Otherwise (only library/alpine) consider the first item from array (library)
+				projectName = repoSplit[0]
+			}
 			var permission string
 			if len(username) > 0 {
 				isAdmin, err := dao.IsAdminRole(username)

--- a/src/ui/service/token/authutils.go
+++ b/src/ui/service/token/authutils.go
@@ -110,7 +110,7 @@ func FilterAccess(username string, a *token.ResourceActions) {
 		if repoLength > 1 { //Only check the permission when the requested image has a namespace, i.e. project
 			var projectName string
 			registryURL := os.Getenv("HARBOR_REG_URL")
-			if repoSplit[0] == registryUrl {
+			if repoSplit[0] == registryURL {
 				projectName = repoSplit[1]
 				log.Infof("Detected Registry URL in Project Name. Assuming this is a notary request and setting Project Name as %s\n", projectName)
 			} else {

--- a/src/ui/service/token/authutils.go
+++ b/src/ui/service/token/authutils.go
@@ -107,11 +107,13 @@ func FilterAccess(username string, a *token.ResourceActions) {
 	if a.Type == "repository" {
 		repoSplit := strings.Split(a.Name, "/")
 		repoLength := len(repoSplit)
-		if repoLength > 1 { //Only check the permission when the requested image has a namespace, i.e. project/alpine
+		if repoLength > 1 { //Only check the permission when the requested image has a namespace, i.e. project
 			var projectName string
-			if repoLength > 2 { //If the repo contains more than 1 separation (as privateregistry.local/library/alpine) consider the second item from array (library)
+			registryUrl := os.Getenv("HARBOR_REG_URL")
+			if repoSplit[0] == registryUrl {
 				projectName = repoSplit[1]
-			} else { // Otherwise (only library/alpine) consider the first item from array (library)
+				log.Infof("Detected Registry URL in Project Name. Assuming this is a notary request and setting Project Name as %s\n", projectName)
+			} else {
 				projectName = repoSplit[0]
 			}
 			var permission string

--- a/src/ui/service/token/authutils.go
+++ b/src/ui/service/token/authutils.go
@@ -107,7 +107,7 @@ func FilterAccess(username string, a *token.ResourceActions) {
 	if a.Type == "repository" {
 		repoSplit := strings.Split(a.Name, "/")
 		repoLength := len(repoSplit)
-		if repoLength > 0 { //Only check the permission when the requested image has a namespace, i.e. project
+		if repoLength > 1 { //Only check the permission when the requested image has a namespace, i.e. project/alpine
 			var projectName string
 			if repoLength > 2 { //If the repo contains more than 1 separation (as privateregistry.local/library/alpine) consider the second item from array (library)
 				projectName = repoSplit[1]

--- a/src/ui/service/token/authutils.go
+++ b/src/ui/service/token/authutils.go
@@ -109,7 +109,7 @@ func FilterAccess(username string, a *token.ResourceActions) {
 		repoLength := len(repoSplit)
 		if repoLength > 1 { //Only check the permission when the requested image has a namespace, i.e. project
 			var projectName string
-			registryUrl := os.Getenv("HARBOR_REG_URL")
+			registryURL := os.Getenv("HARBOR_REG_URL")
 			if repoSplit[0] == registryUrl {
 				projectName = repoSplit[1]
 				log.Infof("Detected Registry URL in Project Name. Assuming this is a notary request and setting Project Name as %s\n", projectName)


### PR DESCRIPTION
This commit solves the issue related on #1012 

Basically, instead of verifying if there is a '/' character on the a.Name variable, it's applied a split function on this string with the '/' character, then verifying the size of array.

Being bigger than 1, it verifies if the array is bigger than 3 (like privaterepo.com/rpkatz/debian) and getting only the 2nd item from array (rpkatz), otherwise (as being smaller than 3, and bigger than 1, like rpkatz/debian) it gets the first item of the array.