### PR TITLE
Make mail identity configurable

### DIFF
--- a/make/common/templates/ui/app.conf
+++ b/make/common/templates/ui/app.conf
@@ -9,6 +9,7 @@ names = en-US|zh-CN
 httpport = 80
 
 [mail]
+identity = $email_identity
 host = $email_server
 port = $email_server_port
 username = $email_username

--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -9,6 +9,7 @@ hostname = reg.mydomain.com
 ui_url_protocol = http
 
 #Email account settings for sending out password resetting emails.
+email_identity = Mail Config
 email_server = smtp.mydomain.com
 email_server_port = 25
 email_username = sample_admin@mydomain.com

--- a/make/prepare
+++ b/make/prepare
@@ -73,6 +73,7 @@ validate(rcp)
 hostname = rcp.get("configuration", "hostname")
 protocol = rcp.get("configuration", "ui_url_protocol")
 ui_url = protocol + "://" + hostname
+email_identity = rcp.get("configuration", "email_identity")
 email_server = rcp.get("configuration", "email_server")
 email_server_port = rcp.get("configuration", "email_server_port")
 email_username = rcp.get("configuration", "email_username")
@@ -191,6 +192,7 @@ render(os.path.join(templates_dir, "ui", "env"),
 
 render(os.path.join(templates_dir, "ui", "app.conf"),
         ui_conf,
+        email_identity=email_identity,
         email_server=email_server,
         email_server_port=email_server_port,
         email_username=email_username,

--- a/src/common/utils/mail.go
+++ b/src/common/utils/mail.go
@@ -134,7 +134,7 @@ func loadConfig() {
 		useTLS = true
 	}
 	mc = MailConfig{
-		Identity: "Mail Config",
+		Identity: config["identity"],
 		Host:     config["host"],
 		Port:     config["port"],
 		Username: config["username"],


### PR DESCRIPTION
The identity field parameter passed to smtp.SendMail is now
configurable instead of being hardcoded to 'Mail Config'.

This fixes issue #900