### PR TITLE
remove rsyslogd.pid before start to allow container restarts

### DIFF
--- a/make/photon/log/Dockerfile
+++ b/make/photon/log/Dockerfile
@@ -20,4 +20,4 @@ VOLUME /var/log/docker/
 
 EXPOSE 514
 
-CMD crond && rsyslogd -n
+CMD crond && rm -f /var/run/rsyslogd.pid && rsyslogd -n


### PR DESCRIPTION
This change mitigate problems with container restarts (stop, start) or automatic restart after host machine restart. Rsyslogd strictly checks existence of its pid file and won't start if such one exists.