### PR TITLE
Fix sync deadlock and filter notification

### DIFF
--- a/make/common/templates/nginx/nginx.http.conf
+++ b/make/common/templates/nginx/nginx.http.conf
@@ -71,5 +71,9 @@ http {
       proxy_buffering off;
       proxy_request_buffering off;
     }
+	
+	location /service/notifications {
+      return 404;
+    }
   }
 }

--- a/make/common/templates/nginx/nginx.https.conf
+++ b/make/common/templates/nginx/nginx.https.conf
@@ -88,6 +88,10 @@ http {
       proxy_buffering off;
       proxy_request_buffering off;
     }
+	
+	location /service/notifications {
+      return 404;
+    }
   }
     server {
       listen 80;

--- a/src/ui/api/repository.go
+++ b/src/ui/api/repository.go
@@ -164,15 +164,15 @@ func (ra *RepositoryAPI) Delete() {
 	}
 
 	for _, t := range tags {
-		if err := rc.DeleteTag(t); err != nil {
+		if err = rc.DeleteTag(t); err != nil {
 			if regErr, ok := err.(*registry_error.Error); ok {
-				if regErr.StatusCode != http.StatusNotFound {
-					ra.CustomAbort(regErr.StatusCode, regErr.Detail)
+				if regErr.StatusCode == http.StatusNotFound {
+					continue
 				}
-			} else {
-				log.Errorf("error occurred while deleting tag %s:%s: %v", repoName, t, err)
-				ra.CustomAbort(http.StatusInternalServerError, "internal error")
+				ra.CustomAbort(regErr.StatusCode, regErr.Detail)
 			}
+			log.Errorf("error occurred while deleting tag %s:%s: %v", repoName, t, err)
+			ra.CustomAbort(http.StatusInternalServerError, "internal error")
 		}
 		log.Infof("delete tag: %s:%s", repoName, t)
 		go TriggerReplicationByRepository(repoName, []string{t}, models.RepOpDelete)


### PR DESCRIPTION
1. Fix issue: deleting repo action will fall in deadlock between two Harbor if they are configured to sync to each other #1222 
2. Filter notification request in nginx