### PR TITLE
fix project name length and follow docker project name rule

### DIFF
--- a/src/ui/api/project.go
+++ b/src/ui/api/project.go
@@ -44,7 +44,8 @@ type projectReq struct {
 }
 
 const projectNameMaxLen int = 30
-const projectNameMinLen int = 4
+const projectNameMinLen int = 2
+const restrictedNameChars = `[a-z0-9]+(?:[._-][a-z0-9]+)*`
 const dupProjectPattern = `Duplicate entry '\w+' for key 'name'`
 
 // Prepare validates the URL and the user
@@ -417,9 +418,9 @@ func isProjectAdmin(userID int, pid int64) bool {
 func validateProjectReq(req projectReq) error {
 	pn := req.ProjectName
 	if isIllegalLength(req.ProjectName, projectNameMinLen, projectNameMaxLen) {
-		return fmt.Errorf("Project name is illegal in length. (greater than 4 or less than 30)")
+		return fmt.Errorf("Project name is illegal in length. (greater than 2 or less than 30)")
 	}
-	validProjectName := regexp.MustCompile(`^[a-z0-9](?:-*[a-z0-9])*(?:[._][a-z0-9](?:-*[a-z0-9])*)*$`)
+	validProjectName := regexp.MustCompile(`^` + restrictedNameChars + `$`)
 	legal := validProjectName.MatchString(pn)
 	if !legal {
 		return fmt.Errorf("project name is not in lower case or contains illegal characters")


### PR DESCRIPTION
name rule:
https://github.com/docker/distribution/blob/master/docs/spec/api.md#overview
...
The rules for a repository name are as follows:

1. A repository name is broken up into path components. A component of a repository name must be at least one lowercase, alpha-numeric characters, optionally separated by periods, dashes or underscores. More strictly, it must match the regular expression [a-z0-9]+(?:[._-][a-z0-9]+)*.
2. If a repository name has two or more path components, they must be separated by a forward slash ("/").
3. The total length of a repository name, including slashes, must be less than 256 characters.

...

