### PR TITLE
Add a default network in docker compose template.

### DIFF
--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -8,6 +8,8 @@ services:
       - /var/log/harbor/:/var/log/docker/
     ports:
       - 1514:514
+    networks:
+      - harbor
   registry:
     image: library/registry:2.5.1
     container_name: registry
@@ -15,6 +17,8 @@ services:
     volumes:
       - /data/registry:/storage
       - ./common/config/registry/:/etc/registry/
+    networks:
+      - harbor
     environment:
       - GODEBUG=netdns=cgo
     command:
@@ -32,6 +36,8 @@ services:
     restart: always
     volumes:
       - /data/database:/var/lib/mysql
+    networks:
+      - harbor
     env_file:
       - ./common/config/db/env
     depends_on:
@@ -51,6 +57,8 @@ services:
       - ./common/config/ui/app.conf:/etc/ui/app.conf
       - ./common/config/ui/private_key.pem:/etc/ui/private_key.pem
       - /data:/harbor_storage
+    networks:
+      - harbor
     depends_on:
       - log
     logging:
@@ -67,6 +75,8 @@ services:
     volumes:
       - /data/job_logs:/var/log/jobs
       - ./common/config/jobservice/app.conf:/etc/jobservice/app.conf
+    networks:
+      - harbor
     depends_on:
       - ui
     logging:
@@ -80,6 +90,8 @@ services:
     restart: always
     volumes:
       - ./common/config/nginx:/etc/nginx
+    networks:
+      - harbor
     ports:
       - 80:80
       - 443:443
@@ -93,3 +105,7 @@ services:
       options:  
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "proxy"
+networks:
+  harbor:
+    external: false
+


### PR DESCRIPTION
The background is, I'll use "extends" to extend the harbor template to harbor+notary template, and add different group of containers in different networks. 

So I add the default network so I can append other networks to container like harbor-ui and nginx.