### PR TITLE
fix the 'v2' URL conflict issue, and remove the workaround

### DIFF
--- a/make/common/templates/nginx/nginx.https.conf
+++ b/make/common/templates/nginx/nginx.https.conf
@@ -62,8 +62,8 @@ http {
       return 404;
     }
 
-    location ~ ^/v2/(.*)/_trust/(.*) {
-      proxy_pass http://notary-server/v2/$$1/_trust/$$2;
+    location /notary/v2/ {
+      proxy_pass http://notary-server/v2/;
       proxy_set_header Host $$http_host;
       proxy_set_header X-Real-IP $$remote_addr;
       proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
@@ -74,6 +74,7 @@ http {
       proxy_buffering off;
       proxy_request_buffering off;
     }
+
     location /v2/ {
       proxy_pass http://registry/v2/;
       proxy_set_header Host $$http_host;

--- a/make/common/templates/notary/server-config.json
+++ b/make/common/templates/notary/server-config.json
@@ -20,7 +20,7 @@
         "type": "token",
         "options": {
             "realm": "$token_endpoint/service/token",
-            "service": "harbor-registry",
+            "service": "harbor-notary",
             "issuer": "harbor-token-issuer",
             "rootcertbundle": "/config/root.crt"
         }

--- a/src/ui/service/token/creator.go
+++ b/src/ui/service/token/creator.go
@@ -63,9 +63,7 @@ func InitCreators() {
 		filterMap: map[string]accessFilter{
 			"repository": &repositoryFilter{
 				//Workaround, had to use same service for both notary and registry
-				parser: &endpointParser{
-					endpoint: ext,
-				},
+				parser: &basicParser{},
 			},
 			"registry": &registryFilter{},
 		},
@@ -102,15 +100,10 @@ func (e endpointParser) parse(s string) (*image, error) {
 	if len(repo) < 2 {
 		return nil, fmt.Errorf("Unable to parse image from string: %s", s)
 	}
-	//Workaround, need to use endpoint Parser to handle both cases.
-	if strings.ContainsRune(repo[0], '.') {
-		if repo[0] != e.endpoint {
-			log.Warningf("Mismatch endpoint from string: %s, expected endpoint: %s, fallback to basic parser", s, e.endpoint)
-			return parseImg(s)
-		}
-		return parseImg(repo[1])
+	if repo[0] != e.endpoint {
+		return nil, fmt.Errorf("Mismatch endpoint from string: %s, expected endpoint: %s", s, e.endpoint)
 	}
-	return parseImg(s)
+	return parseImg(repo[1])
 }
 
 //build Image accepts a string like library/ubuntu:14.04 and build a image struct

--- a/src/ui/service/token/creator.go
+++ b/src/ui/service/token/creator.go
@@ -62,7 +62,6 @@ func InitCreators() {
 		service: registry,
 		filterMap: map[string]accessFilter{
 			"repository": &repositoryFilter{
-				//Workaround, had to use same service for both notary and registry
 				parser: &basicParser{},
 			},
 			"registry": &registryFilter{},

--- a/src/ui/service/token/token_test.go
+++ b/src/ui/service/token/token_test.go
@@ -169,9 +169,8 @@ func TestEndpointParser(t *testing.T) {
 	}
 	testList := []parserTestRec{parserTestRec{"10.117.4.142:5000/library/ubuntu:14.04", image{"library", "ubuntu", "14.04"}, false},
 		parserTestRec{"myimage:14.04", image{}, true},
-		//Test the temp workaround
-		parserTestRec{"10.117.4.142:80/library/myimage:14.04", image{"10.117.4.142:80", "library/myimage", "14.04"}, false},
-		parserTestRec{"library/myimage:14.04", image{"library", "myimage", "14.04"}, false},
+		parserTestRec{"10.117.4.142:80/library/myimage:14.04", image{}, true},
+		parserTestRec{"library/myimage:14.04", image{}, true},
 		parserTestRec{"10.117.4.142:5000/myimage:14.04", image{}, true},
 		parserTestRec{"10.117.4.142:5000/org/team/img", image{"org", "team/img", ""}, false},
 	}


### PR DESCRIPTION
User will have to set the env var like this:

DOCKER_CONTENT_TRUST_SERVER=https://10.117.4.142/notary