### PR TITLE
label volumes for SELinux

### DIFF
--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -5,7 +5,7 @@ services:
     container_name: harbor-log 
     restart: always
     volumes:
-      - /var/log/harbor/:/var/log/docker/
+      - /var/log/harbor/:/var/log/docker/:z
     ports:
       - 1514:514
   registry:
@@ -13,8 +13,8 @@ services:
     container_name: registry
     restart: always
     volumes:
-      - /data/registry:/storage
-      - ./common/config/registry/:/etc/registry/
+      - /data/registry:/storage:z
+      - ./common/config/registry/:/etc/registry/:z
     environment:
       - GODEBUG=netdns=cgo
     command:
@@ -31,7 +31,7 @@ services:
     container_name: harbor-db
     restart: always
     volumes:
-      - /data/database:/var/lib/mysql
+      - /data/database:/var/lib/mysql:z
     env_file:
       - ./common/config/db/env
     depends_on:
@@ -48,9 +48,9 @@ services:
       - ./common/config/ui/env
     restart: always
     volumes:
-      - ./common/config/ui/app.conf:/etc/ui/app.conf
-      - ./common/config/ui/private_key.pem:/etc/ui/private_key.pem
-      - /data:/harbor_storage
+      - ./common/config/ui/app.conf:/etc/ui/app.conf:z
+      - ./common/config/ui/private_key.pem:/etc/ui/private_key.pem:z
+      - /data:/harbor_storage:z
     depends_on:
       - log
     logging:
@@ -65,8 +65,8 @@ services:
       - ./common/config/jobservice/env
     restart: always
     volumes:
-      - /data/job_logs:/var/log/jobs
-      - ./common/config/jobservice/app.conf:/etc/jobservice/app.conf
+      - /data/job_logs:/var/log/jobs:z
+      - ./common/config/jobservice/app.conf:/etc/jobservice/app.conf:z
     depends_on:
       - ui
     logging:
@@ -79,7 +79,7 @@ services:
     container_name: nginx
     restart: always
     volumes:
-      - ./common/config/nginx:/etc/nginx
+      - ./common/config/nginx:/etc/nginx:z
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
allow Harbor to run when dockerd is running with --selinux-enabled

example AVC denials:
type=AVC msg=audit(1488384855.681:154671): avc:  denied  { read } for  pid=454 comm="registry" name="config.yml" dev="dm-8" ino=12583048 scontext=system_u:system_r:svirt_lxc_net_t:s0:c298,c958 tcontext=system_u:object_r:default_t:s0 tclass=file
type=AVC msg=audit(1488384855.681:154671): avc:  denied  { open } for  pid=454 comm="registry" path="/etc/registry/config.yml" dev="dm-8" ino=12583048 scontext=system_u:system_r:svirt_lxc_net_t:s0:c298,c958 tcontext=system_u:object_r:default_t:s0 tclass=file
type=AVC msg=audit(1488384855.687:154672): avc:  denied  { append } for  pid=350 comm=72733A6D61696E20513A526567 name="registry.log" dev="dm-5" ino=4315920 scontext=system_u:system_r:svirt_lxc_net_t:s0:c599,c800 tcontext=system_u:object_r:default_t:s0 tclass=file
type=AVC msg=audit(1488384856.895:154702): avc:  denied  { remove_name } for  pid=708 comm="mysqld" name="4691d4d62464.lower-test" dev="dm-12" ino=402656159 scontext=system_u:system_r:svirt_lxc_net_t:s0:c149,c797 tcontext=system_u:object_r:default_t:s0 tclass=dir
type=AVC msg=audit(1488384856.926:154703): avc:  denied  { lock } for  pid=708 comm="mysqld" path="/var/lib/mysql/ibdata1" dev="dm-12" ino=402656097 scontext=system_u:system_r:svirt_lxc_net_t:s0:c149,c797 tcontext=system_u:object_r:default_t:s0 tclass=file
type=AVC msg=audit(1488384857.958:154736): avc:  denied  { open } for  pid=924 comm="harbor_jobservi" path="/etc/jobservice/app.conf" dev="dm-8" ino=142 scontext=system_u:system_r:svirt_lxc_net_t:s0:c102,c158 tcontext=system_u:object_r:default_t:s0 tclass=file
type=AVC msg=audit(1488384858.089:154737): avc:  denied  { read } for  pid=1017 comm="nginx" name="nginx.conf" dev="dm-8" ino=4194445 scontext=system_u:system_r:svirt_lxc_net_t:s0:c847,c996 tcontext=system_u:object_r:default_t:s0 tclass=file
type=AVC msg=audit(1488384858.089:154737): avc:  denied  { open } for  pid=1017 comm="nginx" path="/etc/nginx/nginx.conf" dev="dm-8" ino=4194445 scontext=system_u:system_r:svirt_lxc_net_t:s0:c847,c996 tcontext=system_u:object_r:default_t:s0 tclass=file

reference: http://www.projectatomic.io/blog/2016/07/docker-selinux-flag/