### PR TITLE
Adding in sAMAccountName attribute as possible username issue #2034

### DIFF
--- a/src/common/utils/ldap/ldap.go
+++ b/src/common/utils/ldap/ldap.go
@@ -217,7 +217,7 @@ func SearchUser(ldapConfs models.LdapConf) ([]models.LdapUser, error) {
 			case "email":
 				u.Email = val
 			case "sAMAccountName":
-				u.Email = val
+				u.Realname = val
 			}
 		}
 		ldapUsers = append(ldapUsers, u)

--- a/src/common/utils/ldap/ldap.go
+++ b/src/common/utils/ldap/ldap.go
@@ -31,7 +31,7 @@ import (
 	goldap "gopkg.in/ldap.v2"
 )
 
-var attributes = []string{"uid", "cn", "mail", "email"}
+var attributes = []string{"uid", "cn", "mail", "email", "sAMAccountName"}
 
 // GetSystemLdapConf ...
 func GetSystemLdapConf() (models.LdapConf, error) {
@@ -215,6 +215,8 @@ func SearchUser(ldapConfs models.LdapConf) ([]models.LdapUser, error) {
 			case "mail":
 				u.Email = val
 			case "email":
+				u.Email = val
+			case "sAMAccountName":
 				u.Email = val
 			}
 		}


### PR DESCRIPTION
When using sAMAccountName as the ldap uid when connecting to Active Directory, harbor is unable to  set the username.  sAMAccountName is not in the list of available attributes to pull the Username from.  #2034 