### PR TITLE
remove ‘required’ flag from 'searchDN and search password' of ldap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,17 @@ src/ui_ng/typings/
 **/node_modules
 **/ssl/
 **/proxy.config.json
+
+src/ui_ng/src/**/*.js
+src/ui_ng/src/**/*.js.map
+src/ui_ng/src/**/*.json
+
 **/npm*.log
 
+src/ui_ng/aot/**/*.js
+src/ui_ng/aot/**/*.js.map
+src/ui_ng/aot/**/*.json
+
+**/*ngsummary.json
+**/*ngfactory.ts
+**/aot

--- a/src/ui_ng/src/app/config/auth/config-auth.component.html
+++ b/src/ui_ng/src/app/config/auth/config-auth.component.html
@@ -29,10 +29,9 @@
                     </label>
         </div>
         <div class="form-group">
-            <label for="ldapSearchDN" class="required">{{'CONFIG.LDAP.SEARCH_DN' | translate}}</label>
-            <label for="ldapSearchDN" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-right" [class.invalid]="ldapSearchDNInput.invalid && (ldapSearchDNInput.dirty || ldapSearchDNInput.touched)">
+            <label for="ldapSearchDN">{{'CONFIG.LDAP.SEARCH_DN' | translate}}</label>
+            <label for="ldapSearchDN" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-right">
                       <input name="ldapSearchDN" type="text" #ldapSearchDNInput="ngModel" [(ngModel)]="currentConfig.ldap_search_dn.value" 
-                      required 
                       id="ldapSearchDN" 
                       size="40" [disabled]="disabled(currentConfig.ldap_search_dn)">
                       <span class="tooltip-content">
@@ -45,10 +44,9 @@
             </a>
         </div>
         <div class="form-group">
-            <label for="ldapSearchPwd" class="required">{{'CONFIG.LDAP.SEARCH_PWD' | translate}}</label>
-            <label for="ldapSearchPwd" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-right" [class.invalid]="ldapSearchPwdInput.invalid && (ldapSearchPwdInput.dirty || ldapSearchPwdInput.touched)">
+            <label for="ldapSearchPwd">{{'CONFIG.LDAP.SEARCH_PWD' | translate}}</label>
+            <label for="ldapSearchPwd" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-right">
                       <input name="ldapSearchPwd" type="password" #ldapSearchPwdInput="ngModel" [(ngModel)]="currentConfig.ldap_search_password.value" 
-                      required 
                       id="ldapSearchPwd" 
                       size="40" [disabled]="disabled(currentConfig.ldap_search_password)">
                       <span class="tooltip-content">

--- a/src/ui_ng/src/app/config/config.component.ts
+++ b/src/ui_ng/src/app/config/config.component.ts
@@ -315,6 +315,9 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
             delete ldapSettings['ldap_search_password'];
         }
 
+        //Fix: Confirm ldap scope is number
+        ldapSettings['ldap_scope'] = +ldapSettings['ldap_scope'];
+
         this.testingLDAPOnGoing = true;
         this.configService.testLDAPServer(ldapSettings)
             .then(respone => {
@@ -401,6 +404,11 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
                     //Fix boolean issue
                     if (typeof field.value === "boolean") {
                         changes[prop] = changes[prop] ? "1" : "0";
+                    }
+
+                    //Trim string value
+                    if(typeof field.value === "string") {
+                        changes[prop] = (''+changes[prop]).trim();
                     }
                 }
             }


### PR DESCRIPTION
remove ‘required’ flag from 'searchDN and search password' of ldap