### PR TITLE
create reverse proxy

### DIFF
--- a/make/common/templates/nginx/nginx.http.conf
+++ b/make/common/templates/nginx/nginx.http.conf
@@ -52,7 +52,7 @@ http {
     }
 
     location /v2/ {
-      proxy_pass http://registry/v2/;
+      proxy_pass http://ui/registryproxy/v2/;
       proxy_set_header Host $$http_host;
       proxy_set_header X-Real-IP $$remote_addr;
       proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
@@ -62,7 +62,6 @@ http {
       
       proxy_buffering off;
       proxy_request_buffering off;
-
     }
 
     location /service/ {

--- a/make/common/templates/nginx/nginx.https.conf
+++ b/make/common/templates/nginx/nginx.https.conf
@@ -71,7 +71,7 @@ http {
     }
 
     location /v2/ {
-      proxy_pass http://registry/v2/;
+      proxy_pass http://ui/registryproxy/v2/;
       proxy_set_header Host $$http_host;
       proxy_set_header X-Real-IP $$remote_addr;
       proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
@@ -81,7 +81,6 @@ http {
 
       proxy_buffering off;
       proxy_request_buffering off;
-
     }
 
     location /service/ {

--- a/src/ui/controllers/proxy.go
+++ b/src/ui/controllers/proxy.go
@@ -1,0 +1,27 @@
+package controllers
+
+import (
+	"strings"
+
+	"github.com/astaxie/beego"
+	"github.com/vmware/harbor/src/ui/proxy"
+)
+
+// RegistryProxy is the endpoint on UI for a reverse proxy pointing to registry
+type RegistryProxy struct {
+	beego.Controller
+}
+
+// Handle is the only entrypoint for incoming requests, all requests must go through this func.
+func (p *RegistryProxy) Handle() {
+	req := p.Ctx.Request
+	rw := p.Ctx.ResponseWriter
+	req.URL.Path = strings.TrimPrefix(req.URL.Path, proxy.RegistryProxyPrefix)
+	//TODO interceptors
+	proxy.Proxy.ServeHTTP(rw, req)
+}
+
+// Render ...
+func (p *RegistryProxy) Render() error {
+	return nil
+}

--- a/src/ui/main.go
+++ b/src/ui/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/vmware/harbor/src/ui/auth/ldap"
 	"github.com/vmware/harbor/src/ui/config"
 	"github.com/vmware/harbor/src/ui/filter"
+	"github.com/vmware/harbor/src/ui/proxy"
 	"github.com/vmware/harbor/src/ui/service/token"
 )
 
@@ -103,5 +104,8 @@ func main() {
 	if err := api.SyncRegistry(); err != nil {
 		log.Error(err)
 	}
+	log.Info("Init proxy")
+	proxy.Init()
+	//go proxy.StartProxy()
 	beego.Run()
 }

--- a/src/ui/proxy/proxy.go
+++ b/src/ui/proxy/proxy.go
@@ -1,0 +1,42 @@
+package proxy
+
+import (
+	"github.com/vmware/harbor/src/ui/config"
+
+	"fmt"
+	"net/http/httputil"
+	"net/url"
+)
+
+// Proxy is the instance of the reverse proxy in this package.
+var Proxy *httputil.ReverseProxy
+
+// RegistryProxyPrefix is the prefix of url on UI.
+const RegistryProxyPrefix = "/registryproxy"
+
+// Init initialize the Proxy instance.
+func Init(urls ...string) error {
+	var err error
+	var registryURL string
+	if len(urls) > 1 {
+		return fmt.Errorf("the parm, urls should have only 0 or 1 elements")
+	}
+	if len(urls) == 0 {
+		registryURL, err = config.RegistryURL()
+		if err != nil {
+			return err
+		}
+	} else {
+		registryURL = urls[0]
+	}
+	targetURL, err := url.Parse(registryURL)
+	if err != nil {
+		return err
+	}
+	Proxy = httputil.NewSingleHostReverseProxy(targetURL)
+	return nil
+}
+
+//func StartProxy(registryURL string) {
+//http.ListenAndServe(":5000", Proxy)
+//}

--- a/src/ui/router.go
+++ b/src/ui/router.go
@@ -107,6 +107,8 @@ func initRouters() {
 	beego.Router("/service/notifications", &service.NotificationHandler{})
 	beego.Router("/service/token", &token.Handler{})
 
+	beego.Router("/registryproxy/*", &controllers.RegistryProxy{}, "*:Handle")
 	//Error pages
 	beego.ErrorController(&controllers.ErrorController{})
+
 }


### PR DESCRIPTION
A reverse proxy is added as a controller on harbor ui.  Interceptors will be added to the proxy handler to block unsigned and vulnerable images according to project policies.