### PR TITLE
Limit clair resource

### DIFF
--- a/make/docker-compose.clair.yml
+++ b/make/docker-compose.clair.yml
@@ -37,6 +37,7 @@ services:
     container_name: clair
     image: vmware/clair:v2.0.1-photon
     restart: always
+    cpu_quota: 150000
     depends_on:
       - postgres
     volumes:


### PR DESCRIPTION
When run clair full scan it will take more than 60% percent of CPU if no limit
this change to limit clair to use at most 1.5cpu

We can this it to cpus when we move to docker compose3.0