### PR TITLE
Correct harbor-py dependencies & URLs

### DIFF
--- a/contrib/sdk/harbor-py/README.md
+++ b/contrib/sdk/harbor-py/README.md
@@ -2,7 +2,9 @@
 
 [harbor](https://github.com/vmware/harbor) is the enterprise-class registry server for docker distribution.
 
-[harbor-py](https://github.com/tobegit3hub/harbor-py) is the native and compatible python SDK for harbor. The supported APIs are list below.
+harbor-py is the native and compatible python SDK for harbor and is included in the harbor git repository under `contrib/sdk/harbor-py`.
+
+The supported APIs are:
 
 - [x] Projects APIs
   - [x] [Get projects](./examples/get_projects.py)
@@ -59,7 +61,7 @@ For more usage, please refer to the [examples](./examples/).
 
 ## Contribution
 
-If you have any suggestion, feel free to submit [issues](https://github.com/tobegit3hub/harbor-py/issues) or send [pull-requests](https://github.com/tobegit3hub/harbor-py/pulls) for `harbor-py`.
+If you have suggestions, feel free to submit [issues](https://github.com/vmware/harbor/issues) or send [pull-requests](https://github.com/vmware/harbor/pulls) for `harbor-py`.
 
 Publish `harbor-py` package to [pypi](https://pypi.python.org/pypi/harbor-py/) server with the following commands.
 

--- a/contrib/sdk/harbor-py/setup.py
+++ b/contrib/sdk/harbor-py/setup.py
@@ -68,7 +68,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    #install_requires=['peppercorn'],
+    install_requires=['requests>2.2.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/contrib/sdk/harbor-py/setup.py
+++ b/contrib/sdk/harbor-py/setup.py
@@ -1,6 +1,6 @@
 """ The missing harbor python SDK
 
-See: https://github.com/tobegit3hub/harbor-py
+See: https://github.com/vmware/harbor/tree/master/contrib/sdk/harbor-py
 """
 
 from setuptools import setup, find_packages
@@ -17,7 +17,7 @@ setup(
     description='The missing harbor python SDK',
 
     # The project's main homepage.
-    url='https://github.com/tobegit3hub/harbor-py',
+    url='https://github.com/vmware/harbor',
 
     # Author details
     author='tobe',


### PR DESCRIPTION
harbor-py requires the requests package, but because it's not specified in `setup.py`, pip doesn't know about it and won't install it as a dependency. This fixes that.

While we're here, let's update the URLs in `setup.py` and `README.md` to point to harbor-py's new location in the main harbor git repo.