### PR TITLE
Updated tests to be more resilient to failures

### DIFF
--- a/tests/coverage4gotest.sh
+++ b/tests/coverage4gotest.sh
@@ -13,7 +13,7 @@ function listDeps(){
 	ds=$(echo $(go list -f '{{.Imports}}' $pkg) | sed 's/[][]//g')
 	for d in $ds
 	do
-		if echo $d | grep -q "github.com/vmware/harbor" && echo $d | grep -qv "vendor"
+		if echo $d | grep -q "github.com/srm912/harbor" && echo $d | grep -qv "vendor"
 		then
 			deps="$deps,$d"
 		fi


### PR DESCRIPTION
This patch is aimed at making the *dao* tests more resistant to failures. The motivation behind this patch was to make the tests more resilient to code panics or exceptions which does not allow the post test cleanup to complete.
This would also make sure that the cleanup tasks are fired irrespective of the test run output, thus eliminating the need for manual cleanups.