### PR TITLE
Updated project publicity API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -193,9 +193,8 @@ paths:
           description: 'Project contains policies, can not be deleted.'
         '500':
           description: Internal errors.
-  '/projects/{project_id}/publicity':
     put:
-      summary: Update properties for a selected project.
+      summary: Update publicity for a selected project.
       description: |
         This endpoint is aimed to toggle a project publicity status.
       parameters:
@@ -205,12 +204,12 @@ paths:
           format: int64
           required: true
           description: Selected project ID.
-        - name: project
+        - name: publicity
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Project'
-          description: Updates of project.
+            $ref: '#/definitions/ProjectPublicity'
+          description: Update publicity of project.
       tags:
         - Products
       responses:
@@ -2047,6 +2046,13 @@ definitions:
       automatically_scan_images_on_push:
         type: boolean
         description: Whether scan images automatically when pushing.
+  ProjectPublicity:
+    type: object
+    properties:
+       publicity:
+        type: integer
+        format: int
+        description: The publicity status of the project to be set.
   Manifest:
     type: object
     properties:

--- a/src/ui/api/harborapi_test.go
+++ b/src/ui/api/harborapi_test.go
@@ -98,7 +98,7 @@ func init() {
 	beego.Router("/api/users", &UserAPI{}, "get:List;post:Post;delete:Delete;put:Put")
 	beego.Router("/api/users/:id([0-9]+)/password", &UserAPI{}, "put:ChangePassword")
 	beego.Router("/api/users/:id/sysadmin", &UserAPI{}, "put:ToggleUserAdminRole")
-	beego.Router("/api/projects/:id/publicity", &ProjectAPI{}, "put:ToggleProjectPublic")
+	beego.Router("/api/projects/:id([0-9]+)", &ProjectAPI{}, "put:ToggleProjectPublic")
 	beego.Router("/api/projects/:id([0-9]+)/logs", &ProjectAPI{}, "get:Logs")
 	beego.Router("/api/projects/:id([0-9]+)/_deletable", &ProjectAPI{}, "get:Deletable")
 	beego.Router("/api/projects/:pid([0-9]+)/members/?:mid", &ProjectMemberAPI{}, "get:Get;post:Post;delete:Delete;put:Put")
@@ -358,23 +358,22 @@ func (a testapi) ProjectsGet(query *apilib.ProjectQuery, authInfo ...usrInfo) (i
 	return httpStatusCode, successPayload, err
 }
 
-//Update properties for a selected project.
+//Update publicity for a selected project.
 func (a testapi) ToggleProjectPublicity(prjUsr usrInfo, projectID string, ispublic int32) (int, error) {
 	// create path and map variables
-	path := "/api/projects/" + projectID + "/publicity/"
+	path := "/api/projects/" + projectID
 	_sling := sling.New().Put(a.basePath)
 
 	_sling = _sling.Path(path)
 
 	type QueryParams struct {
-		Public int32 `json:"public,omitempty"`
+		Public int32 `json:"publicity,omitempty"`
 	}
 
 	_sling = _sling.BodyJSON(&QueryParams{Public: ispublic})
 
 	httpStatusCode, _, err := request(_sling, jsonAcceptHeader, prjUsr)
 	return httpStatusCode, err
-
 }
 
 //Get access logs accompany with a relevant project.

--- a/src/ui/api/project_test.go
+++ b/src/ui/api/project_test.go
@@ -297,16 +297,7 @@ func TestToggleProjectPublicity(t *testing.T) {
 	} else {
 		assert.Equal(int(401), httpStatusCode, "httpStatusCode should be 401")
 	}
-	//-------------------case3: Response Code=400 Invalid project id------------------------------//
-	fmt.Println("case 3: respose code:400, Invalid project id")
-	httpStatusCode, err = apiTest.ToggleProjectPublicity(*admin, "cc", 1)
-	if err != nil {
-		t.Error("Error while search project by proId", err.Error())
-		t.Log(err)
-	} else {
-		assert.Equal(int(400), httpStatusCode, "httpStatusCode should be 400")
-	}
-	//-------------------case4: Response Code=404 Not found the project------------------------------//
+	//-------------------case3: Response Code=404 Not found the project------------------------------//
 	fmt.Println("case 4: respose code:404, Not found the project")
 	httpStatusCode, err = apiTest.ToggleProjectPublicity(*admin, "1234", 1)
 	if err != nil {

--- a/src/ui_ng/src/app/project/project.service.ts
+++ b/src/ui_ng/src/app/project/project.service.ts
@@ -69,7 +69,7 @@ export class ProjectService {
 
   toggleProjectPublic(projectId: number, isPublic: number): Observable<any> {
     return this.http 
-               .put(`/api/projects/${projectId}/publicity`, { 'public': isPublic }, this.options)
+               .put(`/api/projects/${projectId}`, { 'publicity': isPublic }, this.options)
                .map(response=>response.status)
                .catch(error=>Observable.throw(error));
   }


### PR DESCRIPTION
This patch changes the toggle project publicity API to remove the
existing publicity being passed from the UI to the DAO layer.
This makes the API replicate the toggling functionality, by
switching it from public -> private and vice versa without the need
to know the existing publicity.

References #2313 