### PR TITLE
disable nginx buffer

### DIFF
--- a/make/common/templates/nginx/nginx.http.conf
+++ b/make/common/templates/nginx/nginx.http.conf
@@ -59,13 +59,8 @@ http {
       
       # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
       proxy_set_header X-Forwarded-Proto $$scheme;
-
-      proxy_buffer_size 4k;
-      proxy_buffers 4 32k;
-      proxy_busy_buffers_size 64k;
-      proxy_temp_file_write_size 64k;
-      client_body_temp_path /tmp/nginx_client_body_temp;
-      proxy_temp_path /tmp/nginx_proxy_temp;
+      proxy_buffering off;
+      proxy_request_buffering off;
     }
 
     location /service/ {

--- a/make/common/templates/nginx/nginx.https.conf
+++ b/make/common/templates/nginx/nginx.https.conf
@@ -78,13 +78,8 @@ http {
       
       # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
       proxy_set_header X-Forwarded-Proto $$scheme;
-
-      proxy_buffer_size 4k;
-      proxy_buffers 4 32k;
-      proxy_busy_buffers_size 64k;
-      proxy_temp_file_write_size 64k;
-      client_body_temp_path /tmp/nginx_client_body_temp;
-      proxy_temp_path /tmp/nginx_proxy_temp;
+      proxy_buffering off;
+      proxy_request_buffering off;
     }
 
     location /service/ {


### PR DESCRIPTION
When host in low disk status, enable the buffer will cause upload error.