### PR TITLE
replace ADD with COPY for photon/log

### DIFF
--- a/make/photon/log/Dockerfile
+++ b/make/photon/log/Dockerfile
@@ -1,13 +1,13 @@
 FROM vmware/rsyslog-photon:8.15.0
 
-ADD make/common/log/rsyslog.conf /etc/rsyslog.conf
+COPY make/common/log/rsyslog.conf /etc/rsyslog.conf
 
 # rotate logs weekly
 # notes: file name cannot contain dot, or the script will not run
-ADD make/common/log/rotate.sh /etc/cron.weekly/rotate
+COPY make/common/log/rotate.sh /etc/cron.weekly/rotate
 
 # rsyslog configuration file for docker
-ADD make/common/log/rsyslog_docker.conf /etc/rsyslog.d/
+COPY make/common/log/rsyslog_docker.conf /etc/rsyslog.d/
 
 VOLUME /var/log/docker/
 


### PR DESCRIPTION
COPY should be used instead of ADD for the log Dockerfile.

https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy