### PR TITLE
Quote mysql params in alembic.tpl

### DIFF
--- a/tools/migration/alembic.tpl
+++ b/tools/migration/alembic.tpl
@@ -30,7 +30,7 @@ script_location = migration_harbor
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = mysql://$DB_USR:$DB_PWD@localhost:3306/registry
+sqlalchemy.url = mysql://'$DB_USR':'$DB_PWD'@localhost:3306/registry
 
 # Logging configuration
 [loggers]

--- a/tools/migration/run.sh
+++ b/tools/migration/run.sh
@@ -92,10 +92,10 @@ up|upgrade)
     alembic -c ./alembic.ini current
     alembic -c ./alembic.ini upgrade ${VERSION}
     rc="$?"
-    alembic -c ./alembic.ini current	
+    alembic -c ./alembic.ini current
     echo "Upgrade performed."
     echo $rc
-    exit $rc	
+    exit $rc
     ;;
 backup)
     echo "Performing backup..."


### PR DESCRIPTION
Previously, passwords with special characters (namely `%`) would result in an error.  Quoting the parameters should allow for these special characters.