### PR TITLE
Apply project level policies to standalone Harbor

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -167,6 +167,38 @@ paths:
           description: User need to log in first.
         '500':
           description: Internal errors.
+    put:
+      summary: Update properties for a selected project.
+      description: |
+        This endpoint is aimed to update  the properties of a project.
+      parameters:
+        - name: project_id
+          in: path
+          type: integer
+          format: int64
+          required: true
+          description: Selected project ID.
+        - name: project
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Project'
+          description: Updates of project.
+      tags:
+        - Products
+      responses:
+        '200':
+          description: Updated project properties successfully.
+        '400':
+          description: Illegal format of provided ID value.
+        '401':
+          description: User need to log in first.
+        '403':
+          description: User does not have permission to the project.
+        '404':
+          description: Project ID does not exist.
+        '500':
+          description: Unexpected internal errors.
     delete:
       summary: Delete project by projectID
       description: |
@@ -193,39 +225,6 @@ paths:
           description: 'Project contains policies, can not be deleted.'
         '500':
           description: Internal errors.
-  '/projects/{project_id}/publicity':
-    put:
-      summary: Update properties for a selected project.
-      description: |
-        This endpoint is aimed to toggle a project publicity status.
-      parameters:
-        - name: project_id
-          in: path
-          type: integer
-          format: int64
-          required: true
-          description: Selected project ID.
-        - name: project
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/Project'
-          description: Updates of project.
-      tags:
-        - Products
-      responses:
-        '200':
-          description: Updated project publicity status successfully.
-        '400':
-          description: Illegal format of provided ID value.
-        '401':
-          description: User need to log in first.
-        '403':
-          description: User does not have permission to the project.
-        '404':
-          description: Project ID does not exist.
-        '500':
-          description: Unexpected internal errors.
   '/projects/{project_id}/logs':
     get:
       summary: Get access logs accompany with a relevant project.
@@ -2016,10 +2015,6 @@ definitions:
       owner_name:
         type: string
         description: The owner name of the project.
-      public:
-        type: integer
-        format: int
-        description: The public status of the project.
       Togglable:
         type: boolean
         description: >-
@@ -2031,6 +2026,18 @@ definitions:
       repo_count:
         type: integer
         description: The number of the repositories under this project.
+      metadata:
+        type: object
+        description: The metadata of the project.
+        items:
+          $ref: '#/definitions/ProjectMetadata'
+  ProjectMetadata:
+    type: object
+    properties:
+      public:
+        type: integer
+        format: int
+        description: The public status of the project.
       enable_content_trust:
         type: boolean
         description: >-

--- a/make/common/db/registry.sql
+++ b/make/common/db/registry.sql
@@ -73,14 +73,13 @@ create table project (
  creation_time timestamp,
  update_time timestamp,
  deleted tinyint (1) DEFAULT 0 NOT NULL,
- public tinyint (1) DEFAULT 0 NOT NULL,
  primary key (project_id),
  FOREIGN KEY (owner_id) REFERENCES user(user_id),
  UNIQUE (name)
 );
 
-insert into project (owner_id, name, creation_time, update_time, public) values 
-(1, 'library', NOW(), NOW(), 1);
+insert into project (owner_id, name, creation_time, update_time) values 
+(1, 'library', NOW(), NOW());
 
 create table project_member (
  project_id int NOT NULL,

--- a/make/common/db/registry_sqlite.sql
+++ b/make/common/db/registry_sqlite.sql
@@ -71,13 +71,12 @@ create table project (
  creation_time timestamp,
  update_time timestamp,
  deleted tinyint (1) DEFAULT 0 NOT NULL,
- public tinyint (1) DEFAULT 0 NOT NULL,
  FOREIGN KEY (owner_id) REFERENCES user(user_id),
  UNIQUE (name)
 );
 
-insert into project (owner_id, name, creation_time, update_time, public) values 
-(1, 'library', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1);
+insert into project (owner_id, name, creation_time, update_time) values 
+(1, 'library', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 create table project_member (
  project_id int NOT NULL,

--- a/src/common/dao/dao_test.go
+++ b/src/common/dao/dao_test.go
@@ -420,19 +420,6 @@ func TestChangeUserPasswordWithIncorrectOldPassword(t *testing.T) {
 	}
 }
 
-func TestQueryRelevantProjectsWhenNoProjectAdded(t *testing.T) {
-	projects, err := GetHasReadPermProjects(currentUser.Username)
-	if err != nil {
-		t.Errorf("Error occurred in QueryRelevantProjects: %v", err)
-	}
-	if len(projects) != 1 {
-		t.Errorf("Expected only one project in DB, but actual: %d", len(projects))
-	}
-	if projects[0].Name != "library" {
-		t.Errorf("There name of the project does not match, expected: %s, actual: %s", "library", projects[0].Name)
-	}
-}
-
 func TestAddProject(t *testing.T) {
 
 	project := models.Project{
@@ -657,43 +644,6 @@ func TestGetUserByProject(t *testing.T) {
 
 }
 
-func TestToggleProjectPublicity(t *testing.T) {
-	err := ToggleProjectPublicity(currentProject.ProjectID, publicityOn)
-	if err != nil {
-		t.Errorf("Error occurred in ToggleProjectPublicity: %v", err)
-	}
-
-	currentProject, err = GetProjectByName(projectName)
-	if err != nil {
-		t.Errorf("Error occurred in GetProjectByName: %v", err)
-	}
-	if currentProject.Public != publicityOn {
-		t.Errorf("project, id: %d, its publicity is not on", currentProject.ProjectID)
-	}
-	err = ToggleProjectPublicity(currentProject.ProjectID, publicityOff)
-	if err != nil {
-		t.Errorf("Error occurred in ToggleProjectPublicity: %v", err)
-	}
-
-	currentProject, err = GetProjectByName(projectName)
-	if err != nil {
-		t.Errorf("Error occurred in GetProjectByName: %v", err)
-	}
-
-	if currentProject.Public != publicityOff {
-		t.Errorf("project, id: %d, its publicity is not off", currentProject.ProjectID)
-	}
-
-}
-
-/*
-func TestIsProjectPublic(t *testing.T) {
-
-	if isPublic := IsProjectPublic(projectName); isPublic {
-		t.Errorf("project, id: %d, its publicity is not false after turning off", currentProject.ProjectID)
-	}
-}
-*/
 func TestGetUserProjectRoles(t *testing.T) {
 	r, err := GetUserProjectRoles(currentUser.UserID, currentProject.ProjectID)
 	if err != nil {
@@ -710,17 +660,6 @@ func TestGetUserProjectRoles(t *testing.T) {
 	}
 }
 
-/*
-func TestProjectPermission(t *testing.T) {
-	roleCode, err := GetPermission(currentUser.Username, currentProject.Name)
-	if err != nil {
-		t.Errorf("Error occurred in GetPermission: %v", err)
-	}
-	if roleCode != "MDRWS" {
-		t.Errorf("The expected role code is MDRWS,but actual: %s", roleCode)
-	}
-}
-*/
 func TestGetTotalOfProjects(t *testing.T) {
 	total, err := GetTotalOfProjects(nil)
 	if err != nil {
@@ -742,22 +681,6 @@ func TestGetProjects(t *testing.T) {
 	}
 	if projects[1].Name != projectName {
 		t.Errorf("Expected project name in the list: %s, actual: %s", projectName, projects[1].Name)
-	}
-}
-
-func TestGetPublicProjects(t *testing.T) {
-	value := true
-	projects, err := GetProjects(&models.ProjectQueryParam{
-		Public: &value,
-	})
-	if err != nil {
-		t.Errorf("Error occurred in getProjects: %v", err)
-	}
-	if len(projects) != 1 {
-		t.Errorf("Expected length of projects is 1, but actual: %d, the projects: %+v", len(projects), projects)
-	}
-	if projects[0].Name != "library" {
-		t.Errorf("Expected project name in the list: %s, actual: %s", "library", projects[0].Name)
 	}
 }
 

--- a/src/common/dao/pro_meta.go
+++ b/src/common/dao/pro_meta.go
@@ -91,3 +91,12 @@ func paramPlaceholder(n int) string {
 	}
 	return strings.Join(placeholders, ",")
 }
+
+// ListProjectMetadata ...
+func ListProjectMetadata(name, value string) ([]*models.ProjectMetadata, error) {
+	sql := `select * from project_metadata 
+				where name = ? and value = ? and deleted = 0`
+	metadatas := []*models.ProjectMetadata{}
+	_, err := GetOrmer().Raw(sql, name, value).QueryRows(&metadatas)
+	return metadatas, err
+}

--- a/src/common/dao/pro_meta_test.go
+++ b/src/common/dao/pro_meta_test.go
@@ -64,6 +64,12 @@ func TestProMetaDaoMethods(t *testing.T) {
 	assert.Equal(t, value1, m[name1].Value)
 	assert.Equal(t, value2, m[name2].Value)
 
+	// test list
+	metas, err = ListProjectMetadata(name1, value1)
+	require.Nil(t, err)
+	assert.Equal(t, 1, len(metas))
+	assert.Equal(t, int64(1), metas[0].ProjectID)
+
 	// test update
 	newValue1 := "new_value1"
 	meta1.Value = newValue1

--- a/src/common/dao/project.go
+++ b/src/common/dao/project.go
@@ -30,13 +30,13 @@ import (
 func AddProject(project models.Project) (int64, error) {
 
 	o := GetOrmer()
-	p, err := o.Raw("insert into project (owner_id, name, creation_time, update_time, deleted, public) values (?, ?, ?, ?, ?, ?)").Prepare()
+	p, err := o.Raw("insert into project (owner_id, name, creation_time, update_time, deleted) values (?, ?, ?, ?, ?)").Prepare()
 	if err != nil {
 		return 0, err
 	}
 
 	now := time.Now()
-	r, err := p.Exec(project.OwnerID, project.Name, now, now, project.Deleted, project.Public)
+	r, err := p.Exec(project.OwnerID, project.Name, now, now, project.Deleted)
 	if err != nil {
 		return 0, err
 	}
@@ -50,49 +50,11 @@ func AddProject(project models.Project) (int64, error) {
 	return projectID, err
 }
 
-/*
-// IsProjectPublic ...
-func IsProjectPublic(projectName string) bool {
-	project, err := GetProjectByName(projectName)
-	if err != nil {
-		log.Errorf("Error occurred in GetProjectByName: %v", err)
-		return false
-	}
-	if project == nil {
-		return false
-	}
-	return project.Public == 1
-}
-
-//ProjectExists returns whether the project exists according to its name of ID.
-func ProjectExists(nameOrID interface{}) (bool, error) {
-	o := GetOrmer()
-	type dummy struct{}
-	sql := `select project_id from project where deleted = 0 and `
-	switch nameOrID.(type) {
-	case int64:
-		sql += `project_id = ?`
-	case string:
-		sql += `name = ?`
-	default:
-		return false, fmt.Errorf("Invalid nameOrId: %v", nameOrID)
-	}
-
-	var d []dummy
-	num, err := o.Raw(sql, nameOrID).QueryRows(&d)
-	if err != nil {
-		return false, err
-	}
-	return num > 0, nil
-
-}
-*/
-
 // GetProjectByID ...
 func GetProjectByID(id int64) (*models.Project, error) {
 	o := GetOrmer()
 
-	sql := `select p.project_id, p.name, u.username as owner_name, p.owner_id, p.creation_time, p.update_time, p.public  
+	sql := `select p.project_id, p.name, u.username as owner_name, p.owner_id, p.creation_time, p.update_time  
 		from project p left join user u on p.owner_id = u.user_id where p.deleted = 0 and p.project_id = ?`
 	queryParam := make([]interface{}, 1)
 	queryParam = append(queryParam, id)
@@ -127,94 +89,18 @@ func GetProjectByName(name string) (*models.Project, error) {
 	return &p[0], nil
 }
 
-/*
-// GetPermission gets roles that the user has according to the project.
-func GetPermission(username, projectName string) (string, error) {
-	o := GetOrmer()
-
-	sql := `select r.role_code from role as r
-		inner join project_member as pm on r.role_id = pm.role
-		inner join user as u on u.user_id = pm.user_id
-		inner join project p on p.project_id = pm.project_id
-		where u.username = ? and p.name = ? and u.deleted = 0 and p.deleted = 0`
-
-	var r []models.Role
-	n, err := o.Raw(sql, username, projectName).QueryRows(&r)
-	if err != nil {
-		return "", err
-	}
-
-	if n == 0 {
-		return "", nil
-	}
-
-	return r[0].RoleCode, nil
-}
-*/
-
-// ToggleProjectPublicity toggles the publicity of the project.
-func ToggleProjectPublicity(projectID int64, publicity int) error {
-	o := GetOrmer()
-	sql := "update project set public = ? where project_id = ?"
-	_, err := o.Raw(sql, publicity, projectID).Exec()
-	return err
-}
-
-// GetHasReadPermProjects returns a project list,
-// which satisfies the following conditions:
-// 1. the project is not deleted
-// 2. the prject is public or the user is a member of the project
-func GetHasReadPermProjects(username string) ([]*models.Project, error) {
-	user, err := GetUser(models.User{
-		Username: username,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	o := GetOrmer()
-
-	sql :=
-		`select distinct p.project_id, p.name, p.public, 
-			p.owner_id, p.creation_time, p.update_time
-		from project p 
-		left join project_member pm 
-		on p.project_id = pm.project_id 
-		where (pm.user_id = ? or p.public = 1) 
-		and p.deleted = 0 `
-
-	var projects []*models.Project
-
-	if _, err := o.Raw(sql, user.UserID).QueryRows(&projects); err != nil {
-		return nil, err
-	}
-
-	return projects, nil
-}
-
 // GetTotalOfProjects returns the total count of projects
 // according to the query conditions
-func GetTotalOfProjects(query *models.ProjectQueryParam, base ...*models.BaseProjectCollection) (int64, error) {
-
-	var (
-		owner  string
-		name   string
-		public *bool
-		member string
-		role   int
-	)
-
+func GetTotalOfProjects(query *models.ProjectQueryParam) (int64, error) {
+	var pagination *models.Pagination
 	if query != nil {
-		owner = query.Owner
-		name = query.Name
-		public = query.Public
-		if query.Member != nil {
-			member = query.Member.Name
-			role = query.Member.Role
-		}
+		pagination = query.Pagination
+		query.Pagination = nil
 	}
-
-	sql, params := projectQueryConditions(owner, name, public, member, role, base...)
+	sql, params := projectQueryConditions(query)
+	if query != nil {
+		query.Pagination = pagination
+	}
 
 	sql = `select count(*) ` + sql
 
@@ -224,86 +110,39 @@ func GetTotalOfProjects(query *models.ProjectQueryParam, base ...*models.BasePro
 }
 
 // GetProjects returns a project list according to the query conditions
-func GetProjects(query *models.ProjectQueryParam, base ...*models.BaseProjectCollection) ([]*models.Project, error) {
+func GetProjects(query *models.ProjectQueryParam) ([]*models.Project, error) {
+	sql, params := projectQueryConditions(query)
 
-	var (
-		owner  string
-		name   string
-		public *bool
-		member string
-		role   int
-		page   int64
-		size   int64
-	)
-
-	if query != nil {
-		owner = query.Owner
-		name = query.Name
-		public = query.Public
-		if query.Member != nil {
-			member = query.Member.Name
-			role = query.Member.Role
-		}
-		if query.Pagination != nil {
-			page = query.Pagination.Page
-			size = query.Pagination.Size
-		}
-	}
-
-	sql, params := projectQueryConditions(owner, name, public, member, role, base...)
-
-	sql = `select distinct p.project_id, p.name, p.public, p.owner_id, 
+	sql = `select distinct p.project_id, p.name, p.owner_id, 
 				p.creation_time, p.update_time ` + sql
-	if size > 0 {
-		sql += ` limit ?`
-		params = append(params, size)
-
-		if page > 0 {
-			sql += ` offset ?`
-			params = append(params, (page-1)*size)
-		}
-	}
 
 	var projects []*models.Project
 	_, err := GetOrmer().Raw(sql, params).QueryRows(&projects)
 	return projects, err
 }
 
-func projectQueryConditions(owner, name string, public *bool, member string,
-	role int, base ...*models.BaseProjectCollection) (string, []interface{}) {
+func projectQueryConditions(query *models.ProjectQueryParam) (string, []interface{}) {
 	params := []interface{}{}
 
-	// the base project collections:
-	// 1. all projects
-	// 2. public projects
-	// 3. public projects and projects which the user is a member of
-	collection := `project `
-	if len(base) != 0 && base[0] != nil {
-		if len(base[0].Member) == 0 && base[0].Public {
-			collection = `(select * from project pr
-					where pr.public=1) `
-		}
-		if len(base[0].Member) > 0 && base[0].Public {
-			collection = `(select pr.project_id, pr.owner_id, pr.name, pr.
-						creation_time, pr.update_time, pr.deleted, pr.public 
-					from project pr
-					join project_member prm
-						on pr.project_id = prm.project_id
-					join user ur
-						on prm.user_id=ur.user_id
-					where ur.username=?  or pr.public=1 )`
-			params = append(params, base[0].Member)
-		}
+	sql := ` from project as p`
+
+	if query == nil {
+		sql += ` where p.deleted=0 order by p.name`
+		return sql, params
 	}
 
-	sql := ` from ` + collection + ` as p`
+	// if query.ProjectIDs is not nil but has no element, the query will returns no rows
+	if query.ProjectIDs != nil && len(query.ProjectIDs) == 0 {
+		sql += ` where 1 = 0`
+		return sql, params
+	}
 
-	if len(owner) != 0 {
+	if len(query.Owner) != 0 {
 		sql += ` join user u1
 					on p.owner_id = u1.user_id`
 	}
 
-	if len(member) != 0 {
+	if query.Member != nil && len(query.Member.Name) != 0 {
 		sql += ` join project_member pm
 					on p.project_id = pm.project_id
 					join user u2
@@ -311,33 +150,24 @@ func projectQueryConditions(owner, name string, public *bool, member string,
 	}
 	sql += ` where p.deleted=0`
 
-	if len(owner) != 0 {
+	if len(query.Owner) != 0 {
 		sql += ` and u1.username=?`
-		params = append(params, owner)
+		params = append(params, query.Owner)
 	}
 
-	if len(name) != 0 {
+	if len(query.Name) != 0 {
 		sql += ` and p.name like ?`
-		params = append(params, "%"+escape(name)+"%")
+		params = append(params, "%"+escape(query.Name)+"%")
 	}
 
-	if public != nil {
-		sql += ` and p.public = ?`
-		if *public {
-			params = append(params, 1)
-		} else {
-			params = append(params, 0)
-		}
-	}
-
-	if len(member) != 0 {
+	if query.Member != nil && len(query.Member.Name) != 0 {
 		sql += ` and u2.username=?`
-		params = append(params, member)
+		params = append(params, query.Member.Name)
 
-		if role > 0 {
+		if query.Member.Role > 0 {
 			sql += ` and pm.role = ?`
 			roleID := 0
-			switch role {
+			switch query.Member.Role {
 			case common.RoleProjectAdmin:
 				roleID = 1
 			case common.RoleDeveloper:
@@ -350,7 +180,23 @@ func projectQueryConditions(owner, name string, public *bool, member string,
 		}
 	}
 
+	if len(query.ProjectIDs) > 0 {
+		sql += fmt.Sprintf(` and p.project_id in ( %s )`,
+			paramPlaceholder(len(query.ProjectIDs)))
+		params = append(params, query.ProjectIDs)
+	}
+
 	sql += ` order by p.name`
+
+	if query.Pagination != nil && query.Pagination.Size > 0 {
+		sql += ` limit ?`
+		params = append(params, query.Pagination.Size)
+
+		if query.Pagination.Page > 0 {
+			sql += ` offset ?`
+			params = append(params, (query.Pagination.Page-1)*query.Pagination.Size)
+		}
+	}
 
 	return sql, params
 }

--- a/src/common/dao/repository_test.go
+++ b/src/common/dao/repository_test.go
@@ -103,7 +103,6 @@ func TestGetTopRepos(t *testing.T) {
 	project1 := models.Project{
 		OwnerID: 1,
 		Name:    "project1",
-		Public:  0,
 	}
 	project1.ProjectID, err = AddProject(project1)
 	require.NoError(err)
@@ -112,7 +111,6 @@ func TestGetTopRepos(t *testing.T) {
 	project2 := models.Project{
 		OwnerID: 1,
 		Name:    "project2",
-		Public:  0,
 	}
 	project2.ProjectID, err = AddProject(project2)
 	require.NoError(err)
@@ -232,7 +230,6 @@ func TestGetAllRepositories(t *testing.T) {
 	project1 := models.Project{
 		OwnerID: 1,
 		Name:    "projectRepo",
-		Public:  0,
 	}
 	var err2 error
 	project1.ProjectID, err2 = AddProject(project1)

--- a/src/common/models/pro_meta.go
+++ b/src/common/models/pro_meta.go
@@ -18,13 +18,17 @@ import (
 	"time"
 )
 
-// keys of project metadata
+// keys of project metadata and severity values
 const (
 	ProMetaPublic             = "public"
 	ProMetaEnableContentTrust = "enable_content_trust"
-	ProMetaPreventVul         = "prevent_vul"
+	ProMetaPreventVul         = "prevent_vul" //prevent vulnerable images from being pulled
 	ProMetaSeverity           = "severity"
 	ProMetaAutoScan           = "auto_scan"
+	SeverityNone              = "negligible"
+	SeverityLow               = "low"
+	SeverityMedium            = "medium"
+	SeverityHigh              = "high"
 )
 
 // ProjectMetadata holds the metadata of a project.

--- a/src/common/utils/clair/utils.go
+++ b/src/common/utils/clair/utils.go
@@ -30,13 +30,13 @@ import (
 func ParseClairSev(clairSev string) models.Severity {
 	sev := strings.ToLower(clairSev)
 	switch sev {
-	case "negligible":
+	case models.SeverityNone:
 		return models.SevNone
-	case "low":
+	case models.SeverityLow:
 		return models.SevLow
-	case "medium":
+	case models.SeverityMedium:
 		return models.SevMedium
-	case "high":
+	case models.SeverityHigh:
 		return models.SevHigh
 	default:
 		return models.SevUnknown

--- a/src/ui/api/harborapi_test.go
+++ b/src/ui/api/harborapi_test.go
@@ -93,12 +93,11 @@ func init() {
 
 	beego.Router("/api/search/", &SearchAPI{})
 	beego.Router("/api/projects/", &ProjectAPI{}, "get:List;post:Post;head:Head")
-	beego.Router("/api/projects/:id", &ProjectAPI{}, "delete:Delete;get:Get")
+	beego.Router("/api/projects/:id", &ProjectAPI{}, "delete:Delete;get:Get;put:Put")
 	beego.Router("/api/users/:id", &UserAPI{}, "get:Get")
 	beego.Router("/api/users", &UserAPI{}, "get:List;post:Post;delete:Delete;put:Put")
 	beego.Router("/api/users/:id([0-9]+)/password", &UserAPI{}, "put:ChangePassword")
 	beego.Router("/api/users/:id/sysadmin", &UserAPI{}, "put:ToggleUserAdminRole")
-	beego.Router("/api/projects/:id/publicity", &ProjectAPI{}, "put:ToggleProjectPublic")
 	beego.Router("/api/projects/:id([0-9]+)/logs", &ProjectAPI{}, "get:Logs")
 	beego.Router("/api/projects/:id([0-9]+)/_deletable", &ProjectAPI{}, "get:Deletable")
 	beego.Router("/api/projects/:pid([0-9]+)/members/?:mid", &ProjectMemberAPI{}, "get:Get;post:Post;delete:Delete;put:Put")
@@ -359,18 +358,10 @@ func (a testapi) ProjectsGet(query *apilib.ProjectQuery, authInfo ...usrInfo) (i
 }
 
 //Update properties for a selected project.
-func (a testapi) ToggleProjectPublicity(prjUsr usrInfo, projectID string, ispublic int32) (int, error) {
-	// create path and map variables
-	path := "/api/projects/" + projectID + "/publicity/"
-	_sling := sling.New().Put(a.basePath)
-
-	_sling = _sling.Path(path)
-
-	type QueryParams struct {
-		Public int32 `json:"public,omitempty"`
-	}
-
-	_sling = _sling.BodyJSON(&QueryParams{Public: ispublic})
+func (a testapi) ProjectsPut(prjUsr usrInfo, projectID string,
+	project *models.Project) (int, error) {
+	path := "/api/projects/" + projectID
+	_sling := sling.New().Put(a.basePath).Path(path).BodyJSON(project)
 
 	httpStatusCode, _, err := request(_sling, jsonAcceptHeader, prjUsr)
 	return httpStatusCode, err

--- a/src/ui/api/log_test.go
+++ b/src/ui/api/log_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware/harbor/src/common/models"
 	"github.com/vmware/harbor/tests/apitests/apilib"
 )
 
@@ -38,7 +39,7 @@ func TestLogGet(t *testing.T) {
 	fmt.Println("add the project first.")
 	project := apilib.ProjectReq{
 		ProjectName: "project_for_test_log",
-		Public:      1,
+		Metadata:    map[string]string{models.ProMetaPublic: "true"},
 	}
 
 	reply, err := apiTest.ProjectsPost(*testUser, project)

--- a/src/ui/api/search.go
+++ b/src/ui/api/search.go
@@ -147,7 +147,7 @@ func filterRepositories(projects []*models.Project, keyword string) (
 			entry["repository_name"] = r.Name
 			entry["project_name"] = projects[j].Name
 			entry["project_id"] = projects[j].ProjectID
-			entry["project_public"] = projects[j].Public
+			entry["project_public"] = projects[j].IsPublic()
 			entry["pull_count"] = r.PullCount
 
 			tags, err := getTags(r.Name)

--- a/src/ui/api/search_test.go
+++ b/src/ui/api/search_test.go
@@ -37,7 +37,7 @@ func TestSearch(t *testing.T) {
 		assert.Equal(int(200), httpStatusCode, "httpStatusCode should be 200")
 		assert.Equal(int64(1), result.Projects[0].ProjectID, "Project id should be equal")
 		assert.Equal("library", result.Projects[0].Name, "Project name should be library")
-		assert.Equal(1, result.Projects[0].Public, "Project public status should be 1 (true)")
+		assert.True(result.Projects[0].IsPublic(), "Project public status should be 1 (true)")
 	}
 
 	//--------case 2 : Response Code  = 200, sysAdmin and search repo--------//
@@ -49,7 +49,7 @@ func TestSearch(t *testing.T) {
 		assert.Equal(int(200), httpStatusCode, "httpStatusCode should be 200")
 		assert.Equal("library", result.Repositories[0].ProjectName, "Project name should be library")
 		assert.Equal("library/docker", result.Repositories[0].RepositoryName, "Repository  name should be library/docker")
-		assert.Equal(int32(1), result.Repositories[0].ProjectPublic, "Project public status should be 1 (true)")
+		assert.True(result.Repositories[0].ProjectPublic, "Project public status should be 1 (true)")
 	}
 
 	//--------case 3 : Response Code  = 200, normal user and search repo--------//
@@ -61,7 +61,7 @@ func TestSearch(t *testing.T) {
 		assert.Equal(int(200), httpStatusCode, "httpStatusCode should be 200")
 		assert.Equal("library", result.Repositories[0].ProjectName, "Project name should be library")
 		assert.Equal("library/docker", result.Repositories[0].RepositoryName, "Repository  name should be library/docker")
-		assert.Equal(int32(1), result.Repositories[0].ProjectPublic, "Project public status should be 1 (true)")
+		assert.True(result.Repositories[0].ProjectPublic, "Project public status should be 1 (true)")
 	}
 
 }

--- a/src/ui/config/config.go
+++ b/src/ui/config/config.go
@@ -15,7 +15,7 @@
 package config
 
 import (
-	//"crypto/tls"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -108,38 +108,32 @@ func initSecretStore() {
 func initProjectManager() {
 	var driver pmsdriver.PMSDriver
 	if WithAdmiral() {
-		// TODO add support for admiral
-		/*
-			// integration with admiral
-			log.Info("initializing the project manager based on PMS...")
-			// TODO read ca/cert file and pass it to the TLS config
-			AdmiralClient = &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-					},
+		// integration with admiral
+		log.Info("initializing the project manager based on PMS...")
+		// TODO read ca/cert file and pass it to the TLS config
+		AdmiralClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
 				},
-			}
+			},
+		}
 
-			path := os.Getenv("SERVICE_TOKEN_FILE_PATH")
-			if len(path) == 0 {
-				path = defaultTokenFilePath
-			}
-			log.Infof("service token file path: %s", path)
-			TokenReader = &admiral.FileTokenReader{
-				Path: path,
-			}
-			GlobalProjectMgr = admiral.NewProjectManager(AdmiralClient,
-			AdmiralEndpoint(), TokenReader)
-		*/
-		GlobalProjectMgr = nil
+		path := os.Getenv("SERVICE_TOKEN_FILE_PATH")
+		if len(path) == 0 {
+			path = defaultTokenFilePath
+		}
+		log.Infof("service token file path: %s", path)
+		TokenReader = &admiral.FileTokenReader{
+			Path: path,
+		}
+		driver = admiral.NewDriver(AdmiralClient, AdmiralEndpoint(), TokenReader)
 	} else {
 		// standalone
 		log.Info("initializing the project manager based on local database...")
 		driver = local.NewDriver()
-		// TODO move the statement out of the else block when admiral driver is completed
-		GlobalProjectMgr = promgr.NewDefaultProjectManager(driver, true)
 	}
+	GlobalProjectMgr = promgr.NewDefaultProjectManager(driver, true)
 
 }
 

--- a/src/ui/filter/security.go
+++ b/src/ui/filter/security.go
@@ -33,7 +33,7 @@ import (
 	"github.com/vmware/harbor/src/ui/auth"
 	"github.com/vmware/harbor/src/ui/config"
 	"github.com/vmware/harbor/src/ui/promgr"
-	//"github.com/vmware/harbor/src/ui/promgr/pmsdriver/admiral"
+	"github.com/vmware/harbor/src/ui/promgr/pmsdriver/admiral"
 )
 
 type key string
@@ -264,15 +264,13 @@ func (t *tokenReqCtxModifier) Modify(ctx *beegoctx.Context) bool {
 		return false
 	}
 
-	/*
-		log.Debug("creating PMS project manager...")
-		pm := admiral.NewProjectManager(config.AdmiralClient,
-			config.AdmiralEndpoint(), &admiral.RawTokenReader{
-				Token: token,
-			})
-	*/
-	// TODO create the DefaultProjectManager with the real admiral PMSDriver
-	pm := promgr.NewDefaultProjectManager(nil, false)
+	log.Debug("creating PMS project manager...")
+	driver := admiral.NewDriver(config.AdmiralClient,
+		config.AdmiralEndpoint(), &admiral.RawTokenReader{
+			Token: token,
+		})
+
+	pm := promgr.NewDefaultProjectManager(driver, false)
 
 	log.Debug("creating admiral security context...")
 	securCtx := admr.NewSecurityContext(authContext, pm)
@@ -291,13 +289,10 @@ func (u *unauthorizedReqCtxModifier) Modify(ctx *beegoctx.Context) bool {
 	var pm promgr.ProjectManager
 	if config.WithAdmiral() {
 		// integration with admiral
-		/*
-			log.Debug("creating PMS project manager...")
-			pm = admiral.NewProjectManager(config.AdmiralClient,
-				config.AdmiralEndpoint(), nil)
-		*/
-		// TODO create the DefaultProjectManager with the real admiral PMSDriver
-		pm = promgr.NewDefaultProjectManager(nil, false)
+		log.Debug("creating PMS project manager...")
+		driver := admiral.NewDriver(config.AdmiralClient,
+			config.AdmiralEndpoint(), nil)
+		pm = promgr.NewDefaultProjectManager(driver, false)
 		log.Debug("creating admiral security context...")
 		securCtx = admr.NewSecurityContext(nil, pm)
 	} else {

--- a/src/ui/promgr/metamgr/metamgr.go
+++ b/src/ui/promgr/metamgr/metamgr.go
@@ -15,15 +15,13 @@
 package metamgr
 
 import (
-	"strconv"
-
 	"github.com/vmware/harbor/src/common/dao"
 	"github.com/vmware/harbor/src/common/models"
 )
 
-// ProjectMetadataManaegr defines the operations that a project metadata manager should
+// ProjectMetadataManager defines the operations that a project metadata manager should
 // implement
-type ProjectMetadataManaegr interface {
+type ProjectMetadataManager interface {
 	// Add metadatas for project specified by projectID
 	Add(projectID int64, meta map[string]string) error
 	// Delete metadatas whose keys are specified in parameter meta, if it
@@ -34,16 +32,18 @@ type ProjectMetadataManaegr interface {
 	// Get metadatas whose keys are specified in parameter meta, if it is
 	// absent, get all
 	Get(projectID int64, meta ...string) (map[string]string, error)
+	// List metadata according to the name and value
+	List(name, value string) ([]*models.ProjectMetadata, error)
 }
 
-type defaultProjectMetadataManaegr struct{}
+type defaultProjectMetadataManager struct{}
 
 // NewDefaultProjectMetadataManager ...
-func NewDefaultProjectMetadataManager() ProjectMetadataManaegr {
-	return &defaultProjectMetadataManaegr{}
+func NewDefaultProjectMetadataManager() ProjectMetadataManager {
+	return &defaultProjectMetadataManager{}
 }
 
-func (d *defaultProjectMetadataManaegr) Add(projectID int64, meta map[string]string) error {
+func (d *defaultProjectMetadataManager) Add(projectID int64, meta map[string]string) error {
 	for k, v := range meta {
 		proMeta := &models.ProjectMetadata{
 			ProjectID: projectID,
@@ -57,11 +57,11 @@ func (d *defaultProjectMetadataManaegr) Add(projectID int64, meta map[string]str
 	return nil
 }
 
-func (d *defaultProjectMetadataManaegr) Delete(projectID int64, meta ...string) error {
+func (d *defaultProjectMetadataManager) Delete(projectID int64, meta ...string) error {
 	return dao.DeleteProjectMetadata(projectID, meta...)
 }
 
-func (d *defaultProjectMetadataManaegr) Update(projectID int64, meta map[string]string) error {
+func (d *defaultProjectMetadataManager) Update(projectID int64, meta map[string]string) error {
 	for k, v := range meta {
 		if err := dao.UpdateProjectMetadata(&models.ProjectMetadata{
 			ProjectID: projectID,
@@ -72,20 +72,10 @@ func (d *defaultProjectMetadataManaegr) Update(projectID int64, meta map[string]
 		}
 	}
 
-	// TODO remove the logic
-	public, ok := meta[models.ProMetaPublic]
-	if ok {
-		i, err := strconv.Atoi(public)
-		if err != nil {
-			return err
-		}
-		return dao.ToggleProjectPublicity(projectID, i)
-	}
-
 	return nil
 }
 
-func (d *defaultProjectMetadataManaegr) Get(projectID int64, meta ...string) (map[string]string, error) {
+func (d *defaultProjectMetadataManager) Get(projectID int64, meta ...string) (map[string]string, error) {
 	proMetas, err := dao.GetProjectMetadata(projectID, meta...)
 	if err != nil {
 		return nil, nil
@@ -97,4 +87,15 @@ func (d *defaultProjectMetadataManaegr) Get(projectID int64, meta ...string) (ma
 	}
 
 	return m, nil
+}
+
+func (d *defaultProjectMetadataManager) List(name, value string) ([]*models.ProjectMetadata, error) {
+	metas := []*models.ProjectMetadata{}
+	mds, err := dao.ListProjectMetadata(name, value)
+	if err != nil {
+		return nil, err
+	}
+
+	metas = append(metas, mds...)
+	return metas, nil
 }

--- a/src/ui/promgr/metamgr/metamgr_test.go
+++ b/src/ui/promgr/metamgr/metamgr_test.go
@@ -54,6 +54,12 @@ func TestMetaMgrMethods(t *testing.T) {
 	assert.Equal(t, 1, len(m))
 	assert.Equal(t, value, m[key])
 
+	// test list
+	metas, err := mgr.List(key, value)
+	require.Nil(t, err)
+	assert.Equal(t, 1, len(metas))
+	assert.Equal(t, int64(1), metas[0].ProjectID)
+
 	// test update
 	require.Nil(t, mgr.Update(1, map[string]string{
 		key: newValue,

--- a/src/ui/promgr/pmsdriver/driver.go
+++ b/src/ui/promgr/pmsdriver/driver.go
@@ -30,7 +30,5 @@ type PMSDriver interface {
 	// Update the properties of a project
 	Update(projectIDOrName interface{}, project *models.Project) error
 	// List lists projects according to the query conditions
-	// TODO remove base
-	List(query *models.ProjectQueryParam,
-		base ...*models.BaseProjectCollection) (*models.ProjectQueryResult, error)
+	List(query *models.ProjectQueryParam) (*models.ProjectQueryResult, error)
 }

--- a/src/ui/promgr/pmsdriver/local/local.go
+++ b/src/ui/promgr/pmsdriver/local/local.go
@@ -82,7 +82,6 @@ func (d *driver) Create(project *models.Project) (int64, error) {
 	t := time.Now()
 	pro := &models.Project{
 		Name:         project.Name,
-		Public:       project.Public,
 		OwnerID:      project.OwnerID,
 		CreationTime: t,
 		UpdateTime:   t,
@@ -129,16 +128,15 @@ func (d *driver) Update(projectIDOrName interface{},
 	return nil
 }
 
-// TODO remove base
 // List returns a project list according to the query parameters
-func (d *driver) List(query *models.ProjectQueryParam,
-	base ...*models.BaseProjectCollection) (
+func (d *driver) List(query *models.ProjectQueryParam) (
 	*models.ProjectQueryResult, error) {
-	total, err := dao.GetTotalOfProjects(query, base...)
+	total, err := dao.GetTotalOfProjects(query)
 	if err != nil {
 		return nil, err
 	}
-	projects, err := dao.GetProjects(query, base...)
+
+	projects, err := dao.GetProjects(query)
 	if err != nil {
 		return nil, err
 	}

--- a/src/ui/promgr/pmsdriver/local/local_test.go
+++ b/src/ui/promgr/pmsdriver/local/local_test.go
@@ -156,7 +156,9 @@ func TestList(t *testing.T) {
 	id, err := pm.Create(&models.Project{
 		Name:    "get_all_test",
 		OwnerID: 1,
-		Public:  1,
+		Metadata: map[string]string{
+			models.ProMetaPublic: "true",
+		},
 	})
 	assert.Nil(t, err)
 	defer pm.Delete(id)

--- a/src/ui/promgr/promgr_test.go
+++ b/src/ui/promgr/promgr_test.go
@@ -32,7 +32,9 @@ func newFakePMSDriver() pmsdriver.PMSDriver {
 		project: &models.Project{
 			ProjectID: 1,
 			Name:      "library",
-			Public:    1,
+			Metadata: map[string]string{
+				models.ProMetaPublic: "true",
+			},
 		},
 	}
 }
@@ -53,8 +55,7 @@ func (f *fakePMSDriver) Update(projectIDOrName interface{}, project *models.Proj
 	return nil
 }
 
-func (f *fakePMSDriver) List(query *models.ProjectQueryParam,
-	base ...*models.BaseProjectCollection) (*models.ProjectQueryResult, error) {
+func (f *fakePMSDriver) List(query *models.ProjectQueryParam) (*models.ProjectQueryResult, error) {
 	return &models.ProjectQueryResult{
 		Total:    1,
 		Projects: []*models.Project{f.project},
@@ -116,5 +117,5 @@ func TestGetPublic(t *testing.T) {
 	projects, err := proMgr.GetPublic()
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(projects))
-	assert.Equal(t, 1, projects[0].Public)
+	assert.True(t, projects[0].IsPublic())
 }

--- a/src/ui/proxy/interceptors.go
+++ b/src/ui/proxy/interceptors.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -37,9 +36,6 @@ var rec *httptest.ResponseRecorder
 
 // NotaryEndpoint , exported for testing.
 var NotaryEndpoint = config.InternalNotaryEndpoint()
-
-// EnvChecker is the instance of envPolicyChecker
-var EnvChecker = envPolicyChecker{}
 
 // MatchPullManifest checks if the request looks like a request to pull manifest.  If it is returns the image and tag/sha256 digest as 2nd and 3rd return values
 func MatchPullManifest(req *http.Request) (bool, string, string) {
@@ -77,16 +73,6 @@ type policyChecker interface {
 	vulnerablePolicy(name string) (bool, models.Severity)
 }
 
-//For testing
-type envPolicyChecker struct{}
-
-func (ec envPolicyChecker) contentTrustEnabled(name string) bool {
-	return os.Getenv("PROJECT_CONTENT_TRUST") == "1"
-}
-func (ec envPolicyChecker) vulnerablePolicy(name string) (bool, models.Severity) {
-	return os.Getenv("PROJECT_VULNERABLE") == "1", clair.ParseClairSev(os.Getenv("PROJECT_SEVERITY"))
-}
-
 type pmsPolicyChecker struct {
 	pm promgr.ProjectManager
 }
@@ -97,7 +83,7 @@ func (pc pmsPolicyChecker) contentTrustEnabled(name string) bool {
 		log.Errorf("Unexpected error when getting the project, error: %v", err)
 		return true
 	}
-	return project.EnableContentTrust
+	return project.ContentTrustEnabled()
 }
 func (pc pmsPolicyChecker) vulnerablePolicy(name string) (bool, models.Severity) {
 	project, err := pc.pm.Get(name)
@@ -105,7 +91,7 @@ func (pc pmsPolicyChecker) vulnerablePolicy(name string) (bool, models.Severity)
 		log.Errorf("Unexpected error when getting the project, error: %v", err)
 		return true, models.SevUnknown
 	}
-	return project.PreventVulnerableImagesFromRunning, clair.ParseClairSev(project.PreventVulnerableImagesFromRunningSeverity)
+	return project.VulPrevented(), clair.ParseClairSev(project.Severity())
 }
 
 // newPMSPolicyChecker returns an instance of an pmsPolicyChecker
@@ -116,10 +102,7 @@ func newPMSPolicyChecker(pm promgr.ProjectManager) policyChecker {
 }
 
 func getPolicyChecker() policyChecker {
-	if config.WithAdmiral() {
-		return newPMSPolicyChecker(config.GlobalProjectMgr)
-	}
-	return EnvChecker
+	return newPMSPolicyChecker(config.GlobalProjectMgr)
 }
 
 type imageInfo struct {

--- a/src/ui/router.go
+++ b/src/ui/router.go
@@ -70,7 +70,6 @@ func initRouters() {
 		beego.Router("/api/projects/:pid([0-9]+)/members/?:mid", &api.ProjectMemberAPI{})
 		beego.Router("/api/projects/", &api.ProjectAPI{}, "head:Head")
 		beego.Router("/api/projects/:id([0-9]+)", &api.ProjectAPI{})
-		beego.Router("/api/projects/:id([0-9]+)/publicity", &api.ProjectAPI{}, "put:ToggleProjectPublic")
 
 		beego.Router("/api/users/:id", &api.UserAPI{}, "get:Get;delete:Delete;put:Put")
 		beego.Router("/api/users", &api.UserAPI{}, "get:List;post:Post")

--- a/src/ui/service/notifications/registry/handler.go
+++ b/src/ui/service/notifications/registry/handler.go
@@ -16,7 +16,6 @@ package registry
 
 import (
 	"encoding/json"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -170,10 +169,8 @@ func autoScanEnabled(project *models.Project) bool {
 		log.Debugf("Auto Scan disabled because Harbor is not deployed with Clair")
 		return false
 	}
-	if config.WithAdmiral() {
-		return project.AutomaticallyScanImagesOnPush
-	}
-	return os.Getenv("ENABLE_HARBOR_SCAN_ON_PUSH") == "1"
+
+	return project.AutoScan()
 }
 
 // Render returns nil as it won't render any template.

--- a/src/ui_ng/src/app/project/create-project/create-project.component.html
+++ b/src/ui_ng/src/app/project/create-project/create-project.component.html
@@ -23,7 +23,7 @@
                 <div class="form-group" style="padding-left: 135px;">
                     <label class="col-md-4 form-group-label-override">{{'PROJECT.ACCESS_LEVEL' | translate}}</label>
                     <div class="checkbox-inline">
-                        <input type="checkbox" id="create_project_public" [(ngModel)]="project.public" name="public">
+                        <input type="checkbox" id="create_project_public" [(ngModel)]="project.metadata.public" name="public">
                         <label for="create_project_public"></label>
                         <span class="access-level-label">{{ accessLevelDisplayText | translate}}</span>
                         <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-md tooltip-bottom-right" style="top:-8px; left:-8px;">

--- a/src/ui_ng/src/app/project/create-project/create-project.component.ts
+++ b/src/ui_ng/src/app/project/create-project/create-project.component.ts
@@ -73,7 +73,7 @@ export class CreateProjectComponent implements AfterViewChecked, OnInit, OnDestr
     private messageHandlerService: MessageHandlerService) { }
 
   public get accessLevelDisplayText(): string {
-    return this.project.public ? 'PROJECT.PUBLIC' : 'PROJECT.PRIVATE';
+    return this.project.metadata.public ? 'PROJECT.PUBLIC' : 'PROJECT.PRIVATE';
   }
 
   ngOnInit(): void {
@@ -115,7 +115,7 @@ export class CreateProjectComponent implements AfterViewChecked, OnInit, OnDestr
 
     this.isSubmitOnGoing=true;
     this.projectService
-      .createProject(this.project.name, this.project.public ? 1 : 0)
+      .createProject(this.project.name, this.project.metadata)
       .subscribe(
       status => {
         this.isSubmitOnGoing=false;

--- a/src/ui_ng/src/app/project/list-project/list-project.component.html
+++ b/src/ui_ng/src/app/project/list-project/list-project.component.html
@@ -7,11 +7,11 @@
     <clr-dg-row *ngFor="let p of projects">
         <clr-dg-action-overflow [hidden]="!(p.current_user_role_id === 1 || isSystemAdmin)">
             <button class="action-item" (click)="newReplicationRule(p)" [hidden]="!isSystemAdmin">{{'PROJECT.REPLICATION_RULE' | translate}}</button>
-            <button class="action-item" (click)="toggleProject(p)">{{'PROJECT.MAKE' | translate}} {{(p.public === 0 ? 'PROJECT.PUBLIC' : 'PROJECT.PRIVATE') | translate}} </button>
+            <button class="action-item" (click)="toggleProject(p)">{{'PROJECT.MAKE' | translate}} {{(p.metadata.public === 'false' ? 'PROJECT.PUBLIC' : 'PROJECT.PRIVATE') | translate}} </button>
             <button class="action-item" (click)="deleteProject(p)">{{'PROJECT.DELETE' | translate}}</button>
         </clr-dg-action-overflow>
         <clr-dg-cell><a href="javascript:void(0)" (click)="goToLink(p.project_id)">{{p.name}}</a></clr-dg-cell>
-        <clr-dg-cell>{{ (p.public === 1 ? 'PROJECT.PUBLIC' : 'PROJECT.PRIVATE') | translate}}</clr-dg-cell>
+        <clr-dg-cell>{{ (p.metadata.public === 'true' ? 'PROJECT.PUBLIC' : 'PROJECT.PRIVATE') | translate}}</clr-dg-cell>
         <clr-dg-cell *ngIf="showRoleInfo">{{roleInfo[p.current_user_role_id] | translate}}</clr-dg-cell>
         <clr-dg-cell>{{p.repo_count}}</clr-dg-cell>
         <clr-dg-cell>{{p.creation_time | date: 'short'}}</clr-dg-cell>

--- a/src/ui_ng/src/app/project/list-project/list-project.component.ts
+++ b/src/ui_ng/src/app/project/list-project/list-project.component.ts
@@ -173,15 +173,15 @@ export class ListProjectComponent implements OnDestroy {
 
     toggleProject(p: Project) {
         if (p) {
-            p.public === 0 ? p.public = 1 : p.public = 0;
+            p.metadata.public === 'true' ? p.metadata.public = 'false' : p.metadata.public = 'true';
             this.proService
-                .toggleProjectPublic(p.project_id, p.public)
+                .toggleProjectPublic(p.project_id, p.metadata.public)
                 .subscribe(
                 response => {
                     this.msgHandler.showSuccess('PROJECT.TOGGLED_SUCCESS');
                     let pp: Project = this.projects.find((item: Project) => item.project_id === p.project_id);
                     if (pp) {
-                        pp.public = p.public;
+                        pp.metadata.public = p.metadata.public;
                         this.statisticHandler.refresh();
                     }
                 },

--- a/src/ui_ng/src/app/project/project.service.ts
+++ b/src/ui_ng/src/app/project/project.service.ts
@@ -58,20 +58,22 @@ export class ProjectService {
                .catch(error=>Observable.throw(error));
   }
 
-  createProject(name: string, isPublic: number): Observable<any> {
+  createProject(name: string, metadata: any): Observable<any> {
     return this.http
                .post(`/api/projects`,
-                JSON.stringify({'project_name': name, 'public': isPublic})
+                JSON.stringify({'project_name': name, 'metadata': {
+                  public: metadata.public ? 'true' : 'false',
+                }})
                 , this.options)
                .map(response=>response.status)
                .catch(error=>Observable.throw(error));
   }
 
-  toggleProjectPublic(projectId: number, isPublic: number): Observable<any> {
-    return this.http 
-               .put(`/api/projects/${projectId}/publicity`, { 'public': isPublic }, this.options)
-               .map(response=>response.status)
-               .catch(error=>Observable.throw(error));
+  toggleProjectPublic(projectId: number, isPublic: string): Observable<any> {
+    return this.http
+               .put(`/api/projects/${projectId}`, { 'metadata': {'public': isPublic} }, this.options)
+               .map(response => response.status)
+               .catch(error => Observable.throw(error));
   }
 
   deleteProject(projectId: number): Observable<any> {

--- a/src/ui_ng/src/app/project/project.ts
+++ b/src/ui_ng/src/app/project/project.ts
@@ -22,14 +22,14 @@
         "deleted": 0,
         "owner_name": "",
         "public": 1,
-        "Togglable": true,
+        "togglable": true,
         "update_time": "2017-02-10T07:57:56Z",
         "current_user_role_id": 1,
         "repo_count": 0
     }
   ]
 */
-export class Project { 
+export class Project {
     project_id: number;
     owner_id: number;
     name: string;
@@ -37,12 +37,22 @@ export class Project {
     creation_time_str: string;
     deleted: number;
     owner_name: string;
-    public: number;
-    Togglable: boolean;
+    togglable: boolean;
     update_time: Date;
     current_user_role_id: number;
     repo_count: number;
     has_project_admin_role: boolean;
     is_member: boolean;
     role_name: string;
+    metadata: {
+      public: string | boolean;
+      enable_content_trust: string | boolean;
+      prevent_vul: string | boolean;
+      severity: string;
+      auto_scan: string | boolean;
+    };
+    constructor () {
+      this.metadata = <any>{};
+      this.metadata.public = false;
+    }
 }

--- a/tests/apitests/apilib/project.go
+++ b/tests/apitests/apilib/project.go
@@ -45,11 +45,11 @@ type Project struct {
 	// The owner name of the project.
 	OwnerName string `json:"owner_name,omitempty"`
 
-	// The public status of the project.
-	Public int32 `json:"public,omitempty"`
+	// The metadata of the project.
+	Metadata map[string]string `json:"metadata,omitempty"`
 
 	// Correspond to the UI about whether the project's publicity is  updatable (for UI)
-	Togglable bool `json:"Togglable,omitempty"`
+	Togglable bool `json:"togglable,omitempty"`
 
 	// The role ID of the current user who triggered the API (for UI)
 	CurrentUserRoleId int32 `json:"current_user_role_id,omitempty"`

--- a/tests/apitests/apilib/project_req.go
+++ b/tests/apitests/apilib/project_req.go
@@ -23,10 +23,8 @@
 package apilib
 
 type ProjectReq struct {
-
 	// The name of the project.
 	ProjectName string `json:"project_name,omitempty"`
-
-	// The public status of the project.
-	Public int32 `json:"public,omitempty"`
+	// The metadata of the project.
+	Metadata map[string]string `json:"metadata,omitempty"`
 }

--- a/tests/apitests/apilib/search_repository.go
+++ b/tests/apitests/apilib/search_repository.go
@@ -30,8 +30,8 @@ type SearchRepository struct {
 	// The name of the project that the repository belongs to
 	ProjectName string `json:"project_name,omitempty"`
 
-	// The flag to indicate the publicity of the project that the repository belongs to (1 is public, 0 is not)
-	ProjectPublic int32 `json:"project_public,omitempty"`
+	// The flag to indicate the publicity of the project that the repository belongs to
+	ProjectPublic bool `json:"project_public,omitempty"`
 
 	// The name of the repository
 	RepositoryName string `json:"repository_name,omitempty"`

--- a/tools/migration/changelog.md
+++ b/tools/migration/changelog.md
@@ -54,3 +54,4 @@ Changelog for harbor database schema
 
   - create table `project_metadata`
   - insert data into table `project_metadata`
+  - delete column `public` from table `project`


### PR DESCRIPTION
The following features are only enabled in integration mode, this commit moves
these to standalone Harbor:
 - Content trust policy: only signed images can be pulled
 - Vulnerability policy: only images whose severity is below the threshold can be pulled
 - Automatic scan policy: automitic scan pushed images