### PR TITLE
Refine the Dockerfile

### DIFF
--- a/make/common/mariadb/Dockerfile
+++ b/make/common/mariadb/Dockerfile
@@ -2,7 +2,7 @@ FROM vmware/photon:1.0
 
 #The Docker Daemon has to be running with storage backend btrfs when building the image
 
-RUN tdnf distro-sync -y || echo \
+RUN tdnf distro-sync -y \
     && tdnf install -y sed shadow procps-ng gawk gzip sudo net-tools \
     && groupadd -r -g 10000 mysql && useradd --no-log-init -r -g 10000 -u 10000 mysql \
     && tdnf install -y mariadb-server mariadb \

--- a/make/common/nginx/Dockerfile
+++ b/make/common/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM vmware/photon:1.0
 
-RUN tdnf distro-sync -y || echo \
+RUN tdnf distro-sync -y \
     && tdnf install -y nginx \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \

--- a/make/common/postgresql/Dockerfile
+++ b/make/common/postgresql/Dockerfile
@@ -3,7 +3,7 @@ FROM vmware/photon:1.0
 ENV PGDATA /var/lib/postgresql/data
 
 RUN touch /etc/localtime.bak \
-    && tdnf distro-sync -y || echo \
+    && tdnf distro-sync -y \
     && tdnf install -y sed shadow gzip postgresql\
     && groupadd -r postgres --gid=999 \
     && useradd -r -g postgres --uid=999 postgres \

--- a/make/photon/adminserver/Dockerfile
+++ b/make/photon/adminserver/Dockerfile
@@ -1,7 +1,7 @@
 FROM vmware/photon:1.0
 
 RUN tdnf erase vim -y \
-    && tdnf distro-sync -y || echo \
+    && tdnf distro-sync -y \
     && tdnf install -y sudo \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -g 10000 -u 10000 harbor \

--- a/make/photon/jobservice/Dockerfile
+++ b/make/photon/jobservice/Dockerfile
@@ -1,7 +1,7 @@
 FROM vmware/photon:1.0
 
 RUN mkdir /harbor/ \
-    && tdnf distro-sync -y || echo \
+    && tdnf distro-sync -y \
     && tdnf install sudo -y \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -g 10000 -u 10000 harbor 

--- a/make/photon/log/Dockerfile
+++ b/make/photon/log/Dockerfile
@@ -1,6 +1,6 @@
 FROM vmware/photon:1.0
 
-RUN tdnf distro-sync -y || echo \
+RUN tdnf distro-sync -y \
     && tdnf install -y cronie rsyslog logrotate shadow tar gzip sudo net-tools\
     && mkdir /etc/rsyslog.d/ \
     && mkdir /var/spool/rsyslog \
@@ -17,7 +17,7 @@ RUN mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
 
 COPY start.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start.sh && \
-    chown -R 10000:10000 /run 
+    chown -R 10000:10000 /etc/rsyslog.conf /etc/rsyslog.d/ /run 
 
 HEALTHCHECK CMD netstat -ltu|grep 10514
 

--- a/tools/migration/Dockerfile
+++ b/tools/migration/Dockerfile
@@ -1,6 +1,6 @@
 FROM vmware/mariadb-photon:10.2.8
 
-RUN tdnf distro-sync || echo \
+RUN tdnf distro-sync \
     && tdnf install -y mariadb-devel python2 python2-devel python-pip gcc\
     linux-api-headers glibc-devel binutils zlib-devel openssl-devel \
     && pip install mysqlclient alembic \


### PR DESCRIPTION
Refine the Dockerfile to remove temporary workarounds.
Also fixes #3587, to make sure the configuration files of rsyslog can be
read by uid 10000.