### PR TITLE
Fix clair permission issue

### DIFF
--- a/make/photon/clair/docker-entrypoint.sh
+++ b/make/photon/clair/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 chown -R 10000:10000 /config
-sudo -E -u \#10000 sh -c "/dumb-init -- /clair2.0.1/clair -config /config/config.yaml"
+sudo -E -H -u \#10000 sh -c "/dumb-init -- /clair2.0.1/clair -config /config/config.yaml"
 set +e


### PR DESCRIPTION
Clair will call bzr, without -H in sudo it will usr root user's
Home envrionment.