### PR TITLE
Fix Semantic error

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1158,7 +1158,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#definitions/VulnerabilityItem'
+              $ref: '#/definitions/VulnerabilityItem'
         '401':
           description: User needs to login or call the API with correct credentials.
         '403':


### PR DESCRIPTION
When I use 'swagger.yaml' in 'http://editor.swagger.io/', I get error:
Semantic error at paths./repositories/{repo_name}/tags/{tag}/vulnerability/details.get.responses.200.schema.items.$ref
$ref paths must begin with `#/`