### PR TITLE
[SKIP CI] add proxy settings to the API client for the api-testing part

### DIFF
--- a/tests/apitests/api-testing/client/harbor_api_client.go
+++ b/tests/apitests/api-testing/client/harbor_api_client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -22,6 +23,7 @@ type APIClientConfig struct {
 	CaFile   string
 	CertFile string
 	KeyFile  string
+	Proxy    string
 }
 
 //APIClient provided the http client for trigger http requests
@@ -58,6 +60,13 @@ func NewAPIClient(config APIClientConfig) (*APIClient, error) {
 	tlsConfig.BuildNameToCertificate()
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
+	}
+
+	//If proxy should be set
+	if len(strings.TrimSpace(config.Proxy)) > 0 {
+		if proxyURL, err := url.Parse(config.Proxy); err == nil {
+			transport.Proxy = http.ProxyURL(proxyURL)
+		}
 	}
 
 	client := &http.Client{

--- a/tests/apitests/api-testing/envs/environment.go
+++ b/tests/apitests/api-testing/envs/environment.go
@@ -22,6 +22,7 @@ type Environment struct {
 	CAFile         string //env var: CA_FILE_PATH
 	CertFile       string //env var: CERT_FILE_PATH
 	KeyFile        string //env var: KEY_FILE_PATH
+	ProxyURL       string //env var: http_proxy, https_proxy, HTTP_PROXY, HTTPS_PROXY
 
 	//API client
 	HTTPClient *client.APIClient
@@ -95,6 +96,18 @@ func (env *Environment) Load() error {
 		env.CertFile = certFile
 	}
 
+	proxyEnvVar := "https_proxy"
+	if env.Protocol == "http" {
+		proxyEnvVar = "http_proxy"
+	}
+	proxyURL := os.Getenv(proxyEnvVar)
+	if !isNotEmpty(proxyURL) {
+		proxyURL = os.Getenv(strings.ToUpper(proxyEnvVar))
+	}
+	if isNotEmpty(proxyURL) {
+		env.ProxyURL = proxyURL
+	}
+
 	if !env.loaded {
 		cfg := client.APIClientConfig{
 			Username: env.Admin,
@@ -102,6 +115,7 @@ func (env *Environment) Load() error {
 			CaFile:   env.CAFile,
 			CertFile: env.CertFile,
 			KeyFile:  env.KeyFile,
+			Proxy:    env.ProxyURL,
 		}
 
 		httpClient, err := client.NewAPIClient(cfg)


### PR DESCRIPTION
If the 'http_proxy' or 'HTTP_PROXY' env variable is set when protocol is 'http', the testing API client will use that url as proxy settings.
If the 'https_proxy' or 'HTTPS_PROXY' env variable is set when protocol is 'https', the testing API client will use that url as proxy settings.