### PR TITLE
Refactor the configuraiton of UAA

### DIFF
--- a/make/common/templates/adminserver/env
+++ b/make/common/templates/adminserver/env
@@ -44,5 +44,6 @@ RESET=false
 UAA_ENDPOINT=$uaa_endpoint
 UAA_CLIENTID=$uaa_clientid
 UAA_CLIENTSECRET=$uaa_clientsecret
+UAA_VERIFY_CERT=$uaa_verify_cert
 UI_URL=http://ui:8080
 JOBSERVICE_URL=http://jobservice:8080

--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -121,7 +121,7 @@ redis_url =
 #************************END INITIAL PROPERTIES************************
 #The following attributes only need to be set when auth mode is uaa_auth
 uaa_endpoint = uaa.mydomain.org
-uaa_clientid= id
-uaa_clientsecret= secret
-uaa_ca_root= /path/to/uaa_ca.pem
+uaa_clientid = id
+uaa_clientsecret = secret
+uaa_verify_cert = true
 #############

--- a/make/prepare
+++ b/make/prepare
@@ -238,7 +238,7 @@ pg_password = rcp.get("configuration", "clair_db_password")
 uaa_endpoint = rcp.get("configuration", "uaa_endpoint")
 uaa_clientid = rcp.get("configuration", "uaa_clientid")
 uaa_clientsecret = rcp.get("configuration", "uaa_clientsecret")
-uaa_ca_root = rcp.get("configuration", "uaa_ca_root")
+uaa_verify_cert = rcp.get("configuration", "uaa_verify_cert")
 
 secret_key = get_secret_key(secretkey_path)
 log_rotate_count = rcp.get("configuration", "log_rotate_count")
@@ -291,12 +291,6 @@ if protocol == "https":
 else:
     render(os.path.join(templates_dir, "nginx", "nginx.http.conf"),
         nginx_conf)
-
-if auth_mode == "uaa_auth":
-    if os.path.isfile(uaa_ca_root):
-        shutil.copy2(uaa_ca_root, os.path.join(ui_certificates_dir, "uaa_ca.pem"))
-    else:
-        raise Exception("Error: Invalid path for uaa ca root: %s" % uaa_ca_root)
 		
 render(os.path.join(templates_dir, "adminserver", "env"),
         adminserver_conf_env,
@@ -335,7 +329,8 @@ render(os.path.join(templates_dir, "adminserver", "env"),
         pg_password=pg_password,
         uaa_endpoint=uaa_endpoint,
         uaa_clientid=uaa_clientid,
-        uaa_clientsecret=uaa_clientsecret
+        uaa_clientsecret=uaa_clientsecret,
+        uaa_verify_cert=uaa_verify_cert
 	)
 
 render(os.path.join(templates_dir, "ui", "env"), 

--- a/src/adminserver/systemcfg/systemcfg.go
+++ b/src/adminserver/systemcfg/systemcfg.go
@@ -22,14 +22,14 @@ import (
 
 	enpt "github.com/vmware/harbor/src/adminserver/systemcfg/encrypt"
 	"github.com/vmware/harbor/src/adminserver/systemcfg/store"
+	"github.com/vmware/harbor/src/adminserver/systemcfg/store/database"
 	"github.com/vmware/harbor/src/adminserver/systemcfg/store/encrypt"
+	"github.com/vmware/harbor/src/adminserver/systemcfg/store/json"
 	"github.com/vmware/harbor/src/common"
 	comcfg "github.com/vmware/harbor/src/common/config"
-	"github.com/vmware/harbor/src/common/utils/log"
-	"github.com/vmware/harbor/src/adminserver/systemcfg/store/database"
-	"github.com/vmware/harbor/src/common/models"
 	"github.com/vmware/harbor/src/common/dao"
-	"github.com/vmware/harbor/src/adminserver/systemcfg/store/json"
+	"github.com/vmware/harbor/src/common/models"
+	"github.com/vmware/harbor/src/common/utils/log"
 )
 
 const (
@@ -133,8 +133,12 @@ var (
 		common.UAAEndpoint:     "UAA_ENDPOINT",
 		common.UAAClientID:     "UAA_CLIENTID",
 		common.UAAClientSecret: "UAA_CLIENTSECRET",
-		common.UIURL:           "UI_URL",
-		common.JobServiceURL:   "JOBSERVICE_URL",
+		common.UAAVerifyCert: &parser{
+			env:   "UAA_VERIFY_CERT",
+			parse: parseStringToBool,
+		},
+		common.UIURL:         "UI_URL",
+		common.JobServiceURL: "JOBSERVICE_URL",
 	}
 
 	// configurations need read from environment variables
@@ -163,6 +167,7 @@ var (
 		common.UAAEndpoint:     "UAA_ENDPOINT",
 		common.UAAClientID:     "UAA_CLIENTID",
 		common.UAAClientSecret: "UAA_CLIENTSECRET",
+		common.UAAVerifyCert:   "UAA_VERIFY_CERT",
 	}
 )
 
@@ -327,7 +332,7 @@ func LoadFromEnv(cfgs map[string]interface{}, all bool) error {
 }
 
 // GetDatabaseFromCfg Create database object from config
-func GetDatabaseFromCfg(cfg map[string]interface{}) (*models.Database){
+func GetDatabaseFromCfg(cfg map[string]interface{}) *models.Database {
 	database := &models.Database{}
 	database.Type = cfg[common.DatabaseType].(string)
 	mysql := &models.MySQL{}

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -73,7 +73,8 @@ const (
 	UAAEndpoint                = "uaa_endpoint"
 	UAAClientID                = "uaa_client_id"
 	UAAClientSecret            = "uaa_client_secret"
-	DefaultClairEndpoint = "http://clair:6060"
+	UAAVerifyCert              = "uaa_verify_cert"
+	DefaultClairEndpoint       = "http://clair:6060"
 	CfgDriverDB                = "db"
 	CfgDriverJSON              = "json"
 )

--- a/src/common/models/uaa.go
+++ b/src/common/models/uaa.go
@@ -19,5 +19,5 @@ type UAASettings struct {
 	Endpoint     string
 	ClientID     string
 	ClientSecret string
-	CARootPath   string
+	VerifyCert   bool
 }

--- a/src/common/utils/test/adminserver.go
+++ b/src/common/utils/test/adminserver.go
@@ -63,6 +63,7 @@ var adminServerDefaultConfig = map[string]interface{}{
 	common.UAAClientID:                "testid",
 	common.UAAClientSecret:            "testsecret",
 	common.UAAEndpoint:                "10.192.168.5",
+	common.UAAVerifyCert:              false,
 	common.UIURL:                      "http://myui:8888/",
 	common.JobServiceURL:              "http://myjob:8888/",
 }

--- a/src/ui/auth/uaa/uaa.go
+++ b/src/ui/auth/uaa/uaa.go
@@ -38,10 +38,10 @@ func GetClient() (uaa.Client, error) {
 		return nil, err
 	}
 	cfg := &uaa.ClientConfig{
-		ClientID:     UAASettings.ClientID,
-		ClientSecret: UAASettings.ClientSecret,
-		Endpoint:     UAASettings.Endpoint,
-		CARootPath:   UAASettings.CARootPath,
+		ClientID:      UAASettings.ClientID,
+		ClientSecret:  UAASettings.ClientSecret,
+		Endpoint:      UAASettings.Endpoint,
+		SkipTLSVerify: !UAASettings.VerifyCert,
 	}
 	client, err = uaa.NewDefaultClient(cfg)
 	return client, err

--- a/src/ui/config/config.go
+++ b/src/ui/config/config.go
@@ -441,9 +441,7 @@ func UAASettings() (*models.UAASettings, error) {
 		Endpoint:     cfg[common.UAAEndpoint].(string),
 		ClientID:     cfg[common.UAAClientID].(string),
 		ClientSecret: cfg[common.UAAClientSecret].(string),
-	}
-	if len(os.Getenv("UAA_CA_ROOT")) != 0 {
-		us.CARootPath = os.Getenv("UAA_CA_ROOT")
+		VerifyCert:   cfg[common.UAAVerifyCert].(bool),
 	}
 	return us, nil
 }

--- a/src/ui/config/config_test.go
+++ b/src/ui/config/config_test.go
@@ -163,7 +163,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("failed to get UAA setting, error: %v", err)
 	}
 
-	if us.ClientID != "testid" || us.ClientSecret != "testsecret" || us.Endpoint != "10.192.168.5" {
+	if us.ClientID != "testid" || us.ClientSecret != "testsecret" || us.Endpoint != "10.192.168.5" || us.VerifyCert {
 		t.Errorf("Unexpected UAA setting: %+v", *us)
 	}
 	assert.Equal("http://myjob:8888", InternalJobServiceURL())

--- a/tests/coverage4gotest.sh
+++ b/tests/coverage4gotest.sh
@@ -27,7 +27,7 @@ do
 	listDeps $package
 
     echo "DEBUG: testing package $package"
-	go test -v -race -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
+	go test -race -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
 	if [ -f profile.tmp ]	
 	then
 		cat profile.tmp | tail -n +2 >> profile.cov


### PR DESCRIPTION
Remove the attribute "uaa_ca_root" from harbor.cfg and introduce
"uaa_verify_cert".  Similar to LDAP settings, this allow user to
explicitly turn off the cert verification against UAA server, such that
the code will work with self-signed certificate.