### PR TITLE
Provide API to rename admin

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -82,4 +82,5 @@ const (
 	DefaultClairEndpoint       = "http://clair:6060"
 	CfgDriverDB                = "db"
 	CfgDriverJSON              = "json"
+	NewHarborAdminName         = "admin@harbor.local"
 )

--- a/src/common/dao/dao_test.go
+++ b/src/common/dao/dao_test.go
@@ -40,7 +40,7 @@ func execUpdate(o orm.Ormer, sql string, params ...interface{}) error {
 	return nil
 }
 
-func clearUp(username string) {
+func cleanByUser(username string) {
 	var err error
 
 	o := GetOrmer()
@@ -155,7 +155,7 @@ func TestMain(m *testing.M) {
 }
 
 func testForAll(m *testing.M) int {
-	clearUp(username)
+	cleanByUser(username)
 
 	return m.Run()
 }
@@ -1584,6 +1584,12 @@ func TestGetScanJobsByStatus(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(1, len(r2))
 	assert.Equal(sj1.Repository, r2[0].Repository)
+}
+
+func TestIsSuperUser(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(IsSuperUser("admin"))
+	assert.False(IsSuperUser("none"))
 }
 
 func TestSaveConfigEntries(t *testing.T) {

--- a/src/common/dao/user.go
+++ b/src/common/dao/user.go
@@ -296,6 +296,19 @@ func OnBoardUser(u *models.User) error {
 	return nil
 }
 
+//IsSuperUser checks if the user is super user(conventionally id == 1) of Harbor
+func IsSuperUser(username string) bool {
+	u, err := GetUser(models.User{
+		Username: username,
+	})
+	log.Debugf("Check if user %s is super user", username)
+	if err != nil {
+		log.Errorf("Failed to get user from DB, username: %s, error: %v", username, err)
+		return false
+	}
+	return u != nil && u.UserID == 1
+}
+
 //CleanUser - Clean this user information from DB
 func CleanUser(id int64) error {
 	if _, err := GetOrmer().QueryTable(&models.User{}).

--- a/src/ui/auth/authenticator.go
+++ b/src/ui/auth/authenticator.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/vmware/harbor/src/common"
+	"github.com/vmware/harbor/src/common/dao"
 	"github.com/vmware/harbor/src/common/models"
 	"github.com/vmware/harbor/src/common/utils/log"
 	"github.com/vmware/harbor/src/ui/config"
@@ -88,8 +90,8 @@ func Login(m models.AuthModel) (*models.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	if authMode == "" || m.Principal == "admin" {
-		authMode = "db_auth"
+	if authMode == "" || dao.IsSuperUser(m.Principal) {
+		authMode = common.DBAuth
 	}
 	log.Debug("Current AUTH_MODE is ", authMode)
 

--- a/src/ui/controllers/controllers_test.go
+++ b/src/ui/controllers/controllers_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/harbor/src/common"
+	"github.com/vmware/harbor/src/common/dao"
 	"github.com/vmware/harbor/src/common/models"
 	"github.com/vmware/harbor/src/common/utils/test"
 	"github.com/vmware/harbor/src/ui/config"
@@ -124,6 +125,13 @@ func TestAll(t *testing.T) {
 		panic(err)
 	}
 	if err := proxy.Init(); err != nil {
+		panic(err)
+	}
+	database, err := config.Database()
+	if err != nil {
+		panic(err)
+	}
+	if err := dao.InitDatabase(database); err != nil {
 		panic(err)
 	}
 

--- a/src/ui/router.go
+++ b/src/ui/router.go
@@ -86,7 +86,6 @@ func initRouters() {
 	beego.Router("/api/projects/:id([0-9]+)/metadatas/?:name", &api.MetadataAPI{}, "get:Get")
 	beego.Router("/api/projects/:id([0-9]+)/metadatas/", &api.MetadataAPI{}, "post:Post")
 	beego.Router("/api/projects/:id([0-9]+)/metadatas/:name", &api.MetadataAPI{}, "put:Put;delete:Delete")
-	beego.Router("/api/internal/syncregistry", &api.InternalAPI{}, "post:SyncRegistry")
 	beego.Router("/api/repositories", &api.RepositoryAPI{}, "get:Get")
 	beego.Router("/api/repositories/scanAll", &api.RepositoryAPI{}, "post:ScanAll")
 	beego.Router("/api/repositories/*", &api.RepositoryAPI{}, "delete:Delete;put:Put")
@@ -118,6 +117,9 @@ func initRouters() {
 	beego.Router("/api/systeminfo", &api.SystemInfoAPI{}, "get:GetGeneralInfo")
 	beego.Router("/api/systeminfo/volumes", &api.SystemInfoAPI{}, "get:GetVolumeInfo")
 	beego.Router("/api/systeminfo/getcert", &api.SystemInfoAPI{}, "get:GetCert")
+
+	beego.Router("/api/internal/syncregistry", &api.InternalAPI{}, "post:SyncRegistry")
+	beego.Router("/api/internal/renameadmin", &api.InternalAPI{}, "post:RenameAdmin")
 
 	//external service that hosted on harbor process:
 	beego.Router("/service/notifications", &registry.NotificationHandler{})


### PR DESCRIPTION
This is to provide a workaround for very corner case that in user's
authentication backend (LDAP, UAA) has a user called "admin" and because
Harbor's super user is hard coded to "admin" it's not possible to login
the "admin" with credentials in LDAP or UAA.

To minimize the impact, we'll provide an internal API for user to update
the super user's username from "admin" to "admin@harbor.local", this API
can be called by "admin" only, and is not reversible.