### PR TITLE
Add place holder for injecting UAA host

### DIFF
--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -80,6 +80,8 @@ services:
       - /data/secretkey:/etc/ui/key:z
       - /data/ca_download/:/etc/ui/ca/:z
       - /data/psc/:/etc/ui/token/:z
+    extra_hosts:
+      - "PKS_UAA_HOST:127.0.0.1"
     networks:
       - harbor
     depends_on:


### PR DESCRIPTION
As this is for tile deployment only, so add a shortcut for tile/bosh
script to add entry in /etc/hosts inside the container.
Due to effort consideration I don't think we want to render
docker-compose in `prepare` script.