### PR TITLE
WIP: Refine error returned by Authenticator

### DIFF
--- a/src/ui/auth/auth_test.go
+++ b/src/ui/auth/auth_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vmware/harbor/src/common"
 	"github.com/vmware/harbor/src/common/models"
 )
@@ -79,4 +80,11 @@ func TestDefaultOnBoardUser(t *testing.T) {
 	if err != nil {
 		t.Fatal("Default implementation should return nil")
 	}
+}
+
+func TestErrAuth(t *testing.T) {
+	assert := assert.New(t)
+	e := NewErrAuth("test")
+	expectedStr := "Failed to authenticate user, due to error 'test'"
+	assert.Equal(expectedStr, e.Error())
 }

--- a/src/ui/auth/db/db.go
+++ b/src/ui/auth/db/db.go
@@ -31,6 +31,9 @@ func (d *Auth) Authenticate(m models.AuthModel) (*models.User, error) {
 	if err != nil {
 		return nil, err
 	}
+	if u == nil {
+		return nil, auth.NewErrAuth("Invalid credentials")
+	}
 	return u, nil
 }
 

--- a/src/ui/auth/ldap/ldap_test.go
+++ b/src/ui/auth/ldap/ldap_test.go
@@ -108,10 +108,10 @@ func TestMain(m *testing.M) {
 
 func TestAuthenticate(t *testing.T) {
 	var person models.AuthModel
-	var auth *Auth
+	var authHelper *Auth
 	person.Principal = "test"
 	person.Password = "123456"
-	user, err := auth.Authenticate(person)
+	user, err := authHelper.Authenticate(person)
 	if err != nil {
 		t.Errorf("unexpected ldap authenticate fail: %v", err)
 	}
@@ -120,29 +120,23 @@ func TestAuthenticate(t *testing.T) {
 	}
 	person.Principal = "test"
 	person.Password = "1"
-	user, err = auth.Authenticate(person)
-	if err != nil {
-		t.Errorf("unexpected ldap error: %v", err)
-	}
-	if user != nil {
-		t.Errorf("Nil user expected for wrong password")
+	user, err = authHelper.Authenticate(person)
+
+	if _, ok := err.(auth.ErrAuth); !ok {
+		t.Errorf("Expected an ErrAuth on wrong password, but got: %v", err)
 	}
 	person.Principal = ""
 	person.Password = ""
-	user, err = auth.Authenticate(person)
-	if err != nil {
-		t.Errorf("unexpected ldap error: %v", err)
+	user, err = authHelper.Authenticate(person)
+	if _, ok := err.(auth.ErrAuth); !ok {
+		t.Errorf("Expected an ErrAuth on empty credentials, but got: %v", err)
 	}
-	if user != nil {
-		t.Errorf("Nil user for empty credentials")
-	}
-
 	//authenticate the second time
 	person2 := models.AuthModel{
 		Principal: "test",
 		Password:  "123456",
 	}
-	user2, err := auth.Authenticate(person2)
+	user2, err := authHelper.Authenticate(person2)
 
 	if err != nil {
 		t.Errorf("unexpected ldap error: %v", err)

--- a/src/ui/auth/uaa/uaa.go
+++ b/src/ui/auth/uaa/uaa.go
@@ -42,20 +42,20 @@ func (u *Auth) Authenticate(m models.AuthModel) (*models.User, error) {
 		return nil, err
 	}
 	t, err := u.client.PasswordAuth(m.Principal, m.Password)
-	if t != nil && err == nil {
-		user := &models.User{
-			Username: m.Principal,
-		}
-		info, err2 := u.client.GetUserInfo(t.AccessToken)
-		if err2 != nil {
-			log.Warningf("Failed to extract user info from UAA, error: %v", err2)
-		} else {
-			user.Email = info.Email
-			user.Realname = info.Name
-		}
-		return user, nil
+	if err != nil {
+		return nil, auth.NewErrAuth(err.Error())
 	}
-	return nil, err
+	user := &models.User{
+		Username: m.Principal,
+	}
+	info, err2 := u.client.GetUserInfo(t.AccessToken)
+	if err2 != nil {
+		log.Warningf("Failed to extract user info from UAA, error: %v", err2)
+	} else {
+		user.Email = info.Email
+		user.Realname = info.Name
+	}
+	return user, nil
 }
 
 // OnBoardUser will check if a user exists in user table, if not insert the user and


### PR DESCRIPTION
There has been inconsistency in terms of the error returned by
authenticator.
This commit introduces an error ErrAuth to explicitly flag an
authentication failure, which should be treated as user error such
as "invalid credentials", and other errors will be treated as system error.