### PR TITLE
Changed Max Project length

### DIFF
--- a/src/ui/api/project.go
+++ b/src/ui/api/project.go
@@ -42,7 +42,7 @@ type ProjectAPI struct {
 	project *models.Project
 }
 
-const projectNameMaxLen int = 30
+const projectNameMaxLen int = 255
 const projectNameMinLen int = 2
 const restrictedNameChars = `[a-z0-9]+(?:[._-][a-z0-9]+)*`
 


### PR DESCRIPTION
Currently max length for project was statically set to 30 which was increased to 255 in front end but there was no change made to accommodate to backend. This commit fix that bug