### PR TITLE
Add ability to skip check membership on CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,9 +17,11 @@ pipeline:
       SHELL: /bin/bash
     secrets:
       - github_automation_api_key
+      - skip_check_membership
     commands:
       - echo ${DRONE_COMMIT_AUTHOR}
-      - /bin/bash -c '[[ ! $(curl --silent "https://api.github.com/orgs/vmware/members/${DRONE_COMMIT_AUTHOR}?access_token=$GITHUB_AUTOMATION_API_KEY") ]]'
+      - echo $SKIP_CHECK_MEMBERSHIP
+      - if $SKIP_CHECK_MEMBERSHIP == true; then echo 'check-org-membership step skipped'; else /bin/bash -c '[[ ! $(curl --silent "https://api.github.com/orgs/vmware/members/${DRONE_COMMIT_AUTHOR}?access_token=$GITHUB_AUTOMATION_API_KEY") ]]'; fi
     when:
       status: success
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Please submit a PR to contain changes bit by bit. A PR consisting of a lot featu
 
 If you are not a member of `vmware` org in github, then your PR Drone CI build may fail. In that case, request one of the existing members / reviewers to fork your failed build to skip membership checking.
 ```shell
-drone build start --param SKIP_CHECK_MEMBERSHIP=true vmware/vic <Build Number>
+drone build start --param SKIP_CHECK_MEMBERSHIP=true vmware/harbor <Build Number>
 ```
 
 ### Design new features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,11 @@ Pull requests (PR) are always welcome, even they are small fixes like typos or a
 
 Please submit a PR to contain changes bit by bit. A PR consisting of a lot features and code changes may be hard to review. It is recommended to submit PRs in a incremental fasion.
 
+If you are not a member of `vmware` org in github, then your PR Drone CI build may fail. In that case, request one of the existing members / reviewers to fork your failed build to skip membership checking.
+```shell
+drone build start --param SKIP_CHECK_MEMBERSHIP=true vmware/vic <Build Number>
+```
+
 ### Design new features
 
 You can propose new designs for existing Harbor features. You can also design


### PR DESCRIPTION
This is a temporary workaround for external PR builds.