### PR TITLE
Integrate new jobservice into docker-compose template

### DIFF
--- a/make/common/templates/jobservice/app.conf
+++ b/make/common/templates/jobservice/app.conf
@@ -1,5 +1,0 @@
-appname = jobservice
-runmode = dev
-
-[dev]
-httpport = 8080

--- a/make/common/templates/jobservice/config.yml
+++ b/make/common/templates/jobservice/config.yml
@@ -1,0 +1,25 @@
+---
+#Protocol used to serve
+protocol: "http"
+
+#Config certification if use 'https' protocol
+#https_config:
+#  cert: "server.crt"
+#  key: "server.key"
+
+#Server listening port
+port: 8080
+
+#Worker pool
+worker_pool:
+  #0 means unlimited
+  workers: 10
+  backend: "redis"
+  #Additional config if use 'redis' backend
+  #TODO: switch to internal redis endpoint and namespace.
+  redis_pool:
+    host: "redis_host"
+    port: 6379
+    namespace: "namespace"
+#Logger for job
+

--- a/make/common/templates/jobservice/env
+++ b/make/common/templates/jobservice/env
@@ -1,5 +1,3 @@
-LOG_LEVEL=debug
-CONFIG_PATH=/etc/jobservice/app.conf
 UI_SECRET=$ui_secret
 JOBSERVICE_SECRET=$jobservice_secret
 ADMINSERVER_URL=http://adminserver:8080

--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -99,8 +99,7 @@ services:
     restart: always
     volumes:
       - /data/job_logs:/var/log/jobs:z
-      - ./common/config/jobservice/app.conf:/etc/jobservice/app.conf:z
-      - /data/secretkey:/etc/jobservice/key:z
+      - ./common/config/jobservice/config.yml:/etc/jobservice/config.yml:z
     networks:
       - harbor
     depends_on:

--- a/make/photon/jobservice/Dockerfile
+++ b/make/photon/jobservice/Dockerfile
@@ -5,7 +5,6 @@ RUN mkdir /harbor/ \
     && tdnf install sudo -y >> /dev/null\
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -g 10000 -u 10000 harbor 
-HEALTHCHECK CMD curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/api/jobs/replication/1/log|grep 401
 
 COPY ./make/photon/jobservice/start.sh ./make/dev/jobservice/harbor_jobservice /harbor/
 

--- a/make/photon/jobservice/start.sh
+++ b/make/photon/jobservice/start.sh
@@ -8,5 +8,6 @@ fi
 if [ -d /var/log/jobs/scan_job ]; then
     chmod +x /var/log/jobs/scan_job
 fi
-sudo -E -u \#10000 "/harbor/harbor_jobservice"
+
+sudo -E -u \#10000 "/harbor/harbor_jobservice" "-c" "/etc/jobservice/config.yml"
 

--- a/make/prepare
+++ b/make/prepare
@@ -291,7 +291,7 @@ adminserver_conf_env = os.path.join(config_dir, "adminserver", "env")
 ui_conf_env = os.path.join(config_dir, "ui", "env")
 ui_conf = os.path.join(config_dir, "ui", "app.conf")
 ui_cert_dir = os.path.join(config_dir, "ui", "certificates")
-jobservice_conf = os.path.join(config_dir, "jobservice", "app.conf")
+jobservice_conf = os.path.join(config_dir, "jobservice", "config.yml")
 registry_conf = os.path.join(config_dir, "registry", "config.yml")
 db_conf_env = os.path.join(config_dir, "db", "env")
 job_conf_env = os.path.join(config_dir, "jobservice", "env")
@@ -403,7 +403,7 @@ render(os.path.join(templates_dir, "log", "logrotate.conf"),
 		log_rotate_size=log_rotate_size)
 
 print("Generated configuration file: %s" % jobservice_conf)
-shutil.copyfile(os.path.join(templates_dir, "jobservice", "app.conf"), jobservice_conf)
+shutil.copyfile(os.path.join(templates_dir, "jobservice", "config.yml"), jobservice_conf)
 
 print("Generated configuration file: %s" % ui_conf)
 shutil.copyfile(os.path.join(templates_dir, "ui", "app.conf"), ui_conf)


### PR DESCRIPTION
This commit doesn't integrate redis.  No change to makefile b/c it
should work once the temporary jobservice_v2 folder is renamed to jobservice.