### PR TITLE
fix to yaml parse error causing Helm check failure

### DIFF
--- a/contrib/helm/harbor/templates/registry/registry-ss.yaml
+++ b/contrib/helm/harbor/templates/registry/registry-ss.yaml
@@ -61,7 +61,7 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: "registry-data"
-       labels:
+      labels:
 {{ include "harbor.labels" . | indent 8 }}
     spec:
       accessModes: [{{ .Values.registry.volumes.data.accessMode | quote }}]


### PR DESCRIPTION
Error: YAML parse error on harbor/templates/registry/registry-ss.yaml: error converting YAML to JSON: yaml: line 63: did not find expected key