### PR TITLE
Update SQL script to add uuid to job tables.

### DIFF
--- a/make/photon/db/registry.sql
+++ b/make/photon/db/registry.sql
@@ -193,6 +193,8 @@ create table replication_job (
  repository varchar(256) NOT NULL,
  operation  varchar(64) NOT NULL,
  tags   varchar(16384),
+ #New job service only records uuid, for compatibility in this table both IDs are stored.
+ job_uuid varchar(64),
  creation_time timestamp default CURRENT_TIMESTAMP,
  update_time timestamp default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
  PRIMARY KEY (id),
@@ -217,6 +219,8 @@ create table img_scan_job (
  repository varchar(256) NOT NULL,
  tag   varchar(128) NOT NULL,
  digest varchar(128),
+ #New job service only records uuid, for compatibility in this table both IDs are stored.
+ job_uuid varchar(64),
  creation_time timestamp default CURRENT_TIMESTAMP,
  update_time timestamp default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
  PRIMARY KEY (id)

--- a/make/photon/db/registry_sqlite.sql
+++ b/make/photon/db/registry_sqlite.sql
@@ -183,7 +183,6 @@ create table replication_job (
  repository varchar(256) NOT NULL,
  operation  varchar(64) NOT NULL,
  tags   varchar(16384),
- #New job service only records uuid, for compatibility in this table both IDs are stored.
  job_uuid varchar(64),
  creation_time timestamp default CURRENT_TIMESTAMP,
  update_time timestamp default CURRENT_TIMESTAMP
@@ -206,7 +205,6 @@ create table img_scan_job (
  repository varchar(256) NOT NULL,
  tag   varchar(128) NOT NULL,
  digest varchar(64),
- #New job service only records uuid, for compatibility in this table both IDs are stored.
  job_uuid varchar(64),
  creation_time timestamp default CURRENT_TIMESTAMP,
  update_time timestamp default CURRENT_TIMESTAMP

--- a/make/photon/db/registry_sqlite.sql
+++ b/make/photon/db/registry_sqlite.sql
@@ -183,6 +183,8 @@ create table replication_job (
  repository varchar(256) NOT NULL,
  operation  varchar(64) NOT NULL,
  tags   varchar(16384),
+ #New job service only records uuid, for compatibility in this table both IDs are stored.
+ job_uuid varchar(64),
  creation_time timestamp default CURRENT_TIMESTAMP,
  update_time timestamp default CURRENT_TIMESTAMP
  );
@@ -204,6 +206,8 @@ create table img_scan_job (
  repository varchar(256) NOT NULL,
  tag   varchar(128) NOT NULL,
  digest varchar(64),
+ #New job service only records uuid, for compatibility in this table both IDs are stored.
+ job_uuid varchar(64),
  creation_time timestamp default CURRENT_TIMESTAMP,
  update_time timestamp default CURRENT_TIMESTAMP
  );

--- a/tools/migration/db/changelog.md
+++ b/tools/migration/db/changelog.md
@@ -72,3 +72,4 @@ Changelog for harbor database schema
   - create table `harbor_resource_label`
   - create table `user_group`
   - modify table `project_member` use `id` as PK and add column `entity_type` to indicate if the member is user or group.
+  - add `job_uuid` column to `replication_job` and `img_scan_job`


### PR DESCRIPTION
We have to add the uuid/id mapping as new job service will only store uuid.

Further work is in feature branch for now, commit this change to
accelerate migration work.