### PR TITLE
fix size suffix label for >1GB images

### DIFF
--- a/src/ui_ng/lib/src/tag/tag.component.ts
+++ b/src/ui_ng/lib/src/tag/tag.component.ts
@@ -442,7 +442,7 @@ export class TagComponent implements OnInit, AfterViewInit {
     } else if (Math.pow(1024, 2) <= size && size < Math.pow(1024, 3)) {
       return  (size / Math.pow(1024, 2)).toFixed(2) + "MB";
     } else if (Math.pow(1024, 3) <= size && size < Math.pow(1024, 4)) {
-      return  (size / Math.pow(1024, 3)).toFixed(2) + "MB";
+      return  (size / Math.pow(1024, 3)).toFixed(2) + "GB";
     } else {
       return size + "B";
     }


### PR DESCRIPTION
When an image has a size greater than1GB, rendering shows the correct size in GB but with a MB suffix.