### PR TITLE
Bypass docker client retry on push in readonly mode

### DIFF
--- a/src/ui/filter/readonly.go
+++ b/src/ui/filter/readonly.go
@@ -42,6 +42,7 @@ func filter(req *http.Request, resp http.ResponseWriter) {
 	}
 	if matchRepoTagDelete(req) {
 		resp.WriteHeader(http.StatusServiceUnavailable)
+		resp.Write([]byte("The system is in read only mode. Any modification is not prohibited."))
 	}
 }
 

--- a/src/ui/proxy/interceptor_test.go
+++ b/src/ui/proxy/interceptor_test.go
@@ -195,8 +195,10 @@ func TestCopyResp(t *testing.T) {
 
 func TestMarshalError(t *testing.T) {
 	assert := assert.New(t)
-	js := marshalError("Not Found")
-	assert.Equal("{\"errors\":[{\"code\":\"PROJECT_POLICY_VIOLATION\",\"message\":\"Not Found\",\"detail\":\"Not Found\"}]}", js)
+	js1 := marshalError("PROJECT_POLICY_VIOLATION", "Not Found")
+	assert.Equal("{\"errors\":[{\"code\":\"PROJECT_POLICY_VIOLATION\",\"message\":\"Not Found\",\"detail\":\"Not Found\"}]}", js1)
+	js2 := marshalError("DENIED", "The action is denied")
+	assert.Equal("{\"errors\":[{\"code\":\"DENIED\",\"message\":\"The action is denied\",\"detail\":\"The action is denied\"}]}", js2)
 }
 
 func TestIsDigest(t *testing.T) {


### PR DESCRIPTION
The output is,

The push refers to a repository [myregistry/library/busybox]
123abc123abc: Preparing 
denied: Upload/Delete is prohibited in read only mode.
