### PR TITLE
Add initia configuration for  CLAIR_DB.

### DIFF
--- a/make/kubernetes/templates/adminserver.cm.yaml
+++ b/make/kubernetes/templates/adminserver.cm.yaml
@@ -20,6 +20,11 @@ data:
   MYSQL_USR: root
   MYSQL_PWD: "{{db_password}}"
   MYSQL_DATABASE: registry
+  CLAIR_DB_PASSWORD: "{{clair_db_password}}"
+  CLAIR_DB: postgres
+  CLAIR_DB_USERNAME: postgres
+  CLAIR_DB_HOST: postgres
+  CLAIR_DB_PORT: "5432"
   REGISTRY_URL: http://registry:5000
   TOKEN_SERVICE_URL: http://ui/service/token
   EMAIL_HOST: smtp.mydomain.com


### PR DESCRIPTION
When the harbor is deloyed in k8s cluster, the adminserver is not started  due to the lack of clair_db infomation in adminserver.cm.yaml. 
Please refer  to issue 4543 for related error description.