### PR TITLE
Do not run `chown` to config files

### DIFF
--- a/make/common/templates/notary/server-config.json
+++ b/make/common/templates/notary/server-config.json
@@ -6,7 +6,7 @@
 		"type": "remote",
 		"hostname": "notarysigner",
 		"port": "7899",
-		"tls_ca_file": "./notary-signer-ca.crt",
+		"tls_ca_file": "./private/notary-signer-ca.crt",
 		"key_algorithm": "ecdsa"
 	},
 	"logging": {
@@ -22,7 +22,7 @@
             "realm": "$token_endpoint/service/token",
             "service": "harbor-notary",
             "issuer": "harbor-token-issuer",
-            "rootcertbundle": "/config/root.crt"
+            "rootcertbundle": "/etc/notary/private/root.crt"
         }
     }
 }

--- a/make/common/templates/notary/signer-config.json
+++ b/make/common/templates/notary/signer-config.json
@@ -1,8 +1,8 @@
 {
 	"server": {
 		"grpc_addr": ":7899",
-		"tls_cert_file": "./notary-signer.crt",
-		"tls_key_file": "./notary-signer.key"
+		"tls_cert_file": "./private/notary-signer.crt",
+		"tls_key_file": "./private/notary-signer.key"
 	},
 	"logging": {
 		"level": "debug"

--- a/make/docker-compose.clair.tpl
+++ b/make/docker-compose.clair.tpl
@@ -41,7 +41,7 @@ services:
     depends_on:
       - postgres
     volumes:
-      - ./common/config/clair:/config:z
+      - ./common/config/clair/config.yaml:/etc/clair/config.yaml:z
     logging:
       driver: "syslog"
       options:  

--- a/make/docker-compose.notary.tpl
+++ b/make/docker-compose.notary.tpl
@@ -15,7 +15,7 @@ services:
       - notary-sig
       - harbor-notary
     volumes:
-      - ./common/config/notary:/config:z
+      - ./common/config/notary:/etc/notary:z
     depends_on:
       - notary-db
       - notary-signer
@@ -34,7 +34,7 @@ services:
         aliases:
           - notarysigner
     volumes:
-      - ./common/config/notary:/config:z
+      - ./common/config/notary:/etc/notary:z
     env_file:
       - ./common/config/notary/signer_env
     depends_on:

--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -75,11 +75,11 @@ services:
     restart: always
     volumes:
       - ./common/config/ui/app.conf:/etc/ui/app.conf:z
-      - ./common/config/ui/private_key.pem:/etc/ui/private_key.pem:z
-      - ./common/config/ui/certificates/:/etc/ui/certificates/:z
-      - /data/secretkey:/etc/ui/key:z
-      - /data/ca_download/:/etc/ui/ca/:z
-      - /data/psc/:/etc/ui/token/:z
+      - ./common/config/ui/private_key.pem:/etc/ui/private/private_key.pem:z
+      - ./common/config/ui/certificates/:/etc/ui/private/certificates/:z
+      - /data/secretkey:/etc/ui/private/key:z
+      - /data/ca_download/:/etc/ui/private/ca/:z
+      - /data/psc/:/etc/ui/private/token/:z
     networks:
       - harbor
     depends_on:

--- a/make/photon/clair/docker-entrypoint.sh
+++ b/make/photon/clair/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 set -e
-chown -R 10000:10000 /config
-sudo -E -H -u \#10000 sh -c "/dumb-init -- /clair2.0.1/clair -config /config/config.yaml"
+sudo -E -H -u \#10000 sh -c "/dumb-init -- /clair2.0.1/clair -config /etc/clair/config.yaml"
 set +e

--- a/make/photon/jobservice/start.sh
+++ b/make/photon/jobservice/start.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
-if [ -d /etc/jobservice/ ]; then
-    chown -R 10000:10000 /etc/jobservice/ 
-fi
 if [ -d /var/log/jobs ]; then
     chown -R 10000:10000 /var/log/jobs/
 fi

--- a/make/photon/notary/server-start.sh
+++ b/make/photon/notary/server-start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-chown 10000:10000 -R /config
-sudo -E -u \#10000 sh -c "/usr/bin/env /migrations/migrate.sh && /bin/notary-server -config=/config/server-config.json -logf=logfmt"
+chown 10000:10000 -R /etc/notary/private
+sudo -E -u \#10000 sh -c "/usr/bin/env /migrations/migrate.sh && /bin/notary-server -config=/etc/notary/server-config.json -logf=logfmt"

--- a/make/photon/notary/signer-start.sh
+++ b/make/photon/notary/signer-start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-chown 10000:10000 -R /config
-sudo -E -u \#10000 sh -c "/usr/bin/env && /migrations/migrate.sh && /bin/notary-signer -config=/config/signer-config.json -logf=logfmt"
+chown 10000:10000 -R /etc/notary/private
+sudo -E -u \#10000 sh -c "/usr/bin/env && /migrations/migrate.sh && /bin/notary-signer -config=/etc/notary/signer-config.json -logf=logfmt"

--- a/make/photon/ui/start.sh
+++ b/make/photon/ui/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-if [ -d /etc/ui/ ]; then
-    chown -R 10000:10000 /etc/ui/ 
+if [ -d /etc/ui/private ]; then
+    chown -R 10000:10000 /etc/ui/private
 fi
 sudo -E -u \#10000 "/harbor/harbor_ui"
 

--- a/make/prepare
+++ b/make/prepare
@@ -146,8 +146,8 @@ def _get_secret(folder, filename, length=16):
     os.chmod(key_file, 0o600)
     return key
 
-def prep_conf_dir(root, name):
-    absolute_path = os.path.join(root, name)
+def prep_conf_dir(root, *name):
+    absolute_path = os.path.join(root, *name)
     if not os.path.exists(absolute_path):
         os.makedirs(absolute_path)
     return absolute_path
@@ -497,6 +497,7 @@ else:
 
 if args.notary_mode:
     notary_config_dir = prep_conf_dir(config_dir, "notary")
+    notary_config_private_dir = prep_conf_dir(config_dir, "notary", "private")
     notary_temp_dir = os.path.join(templates_dir, "notary") 
     print("Copying sql file for notary DB")
     if os.path.exists(os.path.join(notary_config_dir, "mysql-initdb.d")):
@@ -519,9 +520,9 @@ if args.notary_mode:
             os.chmod(signer_cert_path, 0o600)
             os.chmod(signer_key_path, 0o600)
             os.chmod(signer_ca_cert, 0o600)
-            shutil.copy2(signer_cert_path, notary_config_dir)
-            shutil.copy2(signer_key_path, notary_config_dir)
-            shutil.copy2(signer_ca_cert, notary_config_dir)
+            shutil.copy2(signer_cert_path, notary_config_private_dir)
+            shutil.copy2(signer_key_path, notary_config_private_dir)
+            shutil.copy2(signer_ca_cert, notary_config_private_dir)
         finally:
             srl_tmp = os.path.join(os.getcwd(), ".srl")
             if os.path.isfile(srl_tmp):
@@ -530,10 +531,10 @@ if args.notary_mode:
                 shutil.rmtree(temp_cert_dir, True)
     else:
         print("Copying certs for notary signer")
-        shutil.copy2(os.path.join(notary_temp_dir, "notary-signer.crt"), notary_config_dir)
-        shutil.copy2(os.path.join(notary_temp_dir, "notary-signer.key"), notary_config_dir)
-        shutil.copy2(os.path.join(notary_temp_dir, "notary-signer-ca.crt"), notary_config_dir)
-    shutil.copy2(os.path.join(registry_config_dir, "root.crt"), notary_config_dir)
+        shutil.copy2(os.path.join(notary_temp_dir, "notary-signer.crt"), notary_config_private_dir)
+        shutil.copy2(os.path.join(notary_temp_dir, "notary-signer.key"), notary_config_private_dir)
+        shutil.copy2(os.path.join(notary_temp_dir, "notary-signer-ca.crt"), notary_config_private_dir)
+    shutil.copy2(os.path.join(registry_config_dir, "root.crt"), notary_config_private_dir)
     print("Copying notary signer configuration file")
     shutil.copy2(os.path.join(notary_temp_dir, "signer-config.json"), notary_config_dir)
     render(os.path.join(notary_temp_dir, "server-config.json"),

--- a/src/common/utils/notary/helper.go
+++ b/src/common/utils/notary/helper.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	notaryCachePath = "/etc/ui/notary-cache"
+	notaryCachePath = "/etc/ui/private/notary-cache"
 	trustPin        trustpinning.TrustPinConfig
 	mockRetriever   notary.PassRetriever
 )

--- a/src/ui/config/config.go
+++ b/src/ui/config/config.go
@@ -38,8 +38,9 @@ import (
 )
 
 const (
-	defaultKeyPath       string = "/etc/ui/key"
-	defaultTokenFilePath string = "/etc/ui/token/tokens.properties"
+	defaultKeyPath                     = "/etc/ui/private/key"
+	defaultTokenFilePath               = "/etc/ui/private/token/tokens.properties"
+	defaultRegistryTokenPrivateKeyPath = "/etc/ui/private/private_key.pem"
 )
 
 var (
@@ -56,8 +57,8 @@ var (
 	AdmiralClient *http.Client
 	// TokenReader is used in integration mode to read token
 	TokenReader admiral.TokenReader
-
-	defaultCACertPath = "/etc/ui/ca/ca.crt"
+	// defined as a var for testing.
+	defaultCACertPath = "/etc/ui/private/ca/ca.crt"
 )
 
 // Init configurations
@@ -187,6 +188,15 @@ func AuthMode() (string, error) {
 		return "", err
 	}
 	return cfg[common.AUTHMode].(string), nil
+}
+
+// TokenPrivateKeyPath returns the path to the key for signing token for registry
+func TokenPrivateKeyPath() string {
+	path := os.Getenv("TOKEN_PRIVATE_KEY_PATH")
+	if len(path) == 0 {
+		path = defaultRegistryTokenPrivateKeyPath
+	}
+	return path
 }
 
 // LDAPConf returns the setting of ldap server

--- a/src/ui/config/config_test.go
+++ b/src/ui/config/config_test.go
@@ -185,6 +185,10 @@ func TestConfig(t *testing.T) {
 		t.Errorf("unexpected scan all policy %v", s)
 	}
 
+	if TokenKeyPath := TokenPrivateKeyPath(); TokenKeyPath != "/etc/ui/private/private_key.pem" {
+		t.Errorf("Unexpected token private key path: %s, expected: %s", TokenKeyPath, "/etc/ui/private/private_key.pem")
+	}
+
 	us, err := UAASettings()
 	if err != nil {
 		t.Fatalf("failed to get UAA setting, error: %v", err)

--- a/src/ui/service/token/authutils.go
+++ b/src/ui/service/token/authutils.go
@@ -39,7 +39,7 @@ const (
 var privateKey string
 
 func init() {
-	privateKey = "/etc/ui/private_key.pem"
+	privateKey = config.TokenPrivateKeyPath()
 }
 
 // GetResourceActions ...

--- a/tests/testprepare.sh
+++ b/tests/testprepare.sh
@@ -2,8 +2,8 @@
 set -e
 cp tests/docker-compose.test.yml make/.
 
-mkdir -p /etc/ui
-cp make/common/config/ui/private_key.pem /etc/ui/.
+mkdir -p /etc/ui/private
+cp make/common/config/ui/private_key.pem /etc/ui/private/
 
 mkdir src/ui/conf
 cp make/common/config/ui/app.conf src/ui/conf/.


### PR DESCRIPTION
As described in #4496, a recent security enhancement in kubernetes mount
configMap volume as readonly.  This commit make necessary update to the
entry points scripts and path of the config files to follow this
convention, such that the `chown` will not be called against them.

