### PR TITLE
Bug fix

### DIFF
--- a/src/ui/api/repository.go
+++ b/src/ui/api/repository.go
@@ -324,7 +324,7 @@ func (ra *RepositoryAPI) Delete() {
 			return
 		}
 		if repository == nil {
-			ra.HandleNotFound(fmt.Sprintf("repository %s not found", repoName))
+			log.Warningf("the repository %s not found after deleting tags", repoName)
 			return
 		}
 


### PR DESCRIPTION
When deleting tags belonged to the same repository concurrently, the repository may be deleted by one API call and the other calls get 404. This commit logs a warning message and doesn't return 404.