### PR TITLE
Update harbor default log level to info

### DIFF
--- a/make/common/templates/adminserver/env
+++ b/make/common/templates/adminserver/env
@@ -1,5 +1,5 @@
 PORT=8080
-LOG_LEVEL=debug
+LOG_LEVEL=info
 EXT_ENDPOINT=$public_url
 AUTH_MODE=$auth_mode
 SELF_REGISTRATION=$self_registration

--- a/make/common/templates/ui/env
+++ b/make/common/templates/ui/env
@@ -1,4 +1,4 @@
-LOG_LEVEL=debug
+LOG_LEVEL=info
 CONFIG_PATH=/etc/ui/app.conf
 UI_SECRET=$ui_secret
 JOBSERVICE_SECRET=$jobservice_secret


### PR DESCRIPTION
To set the release default log level of adminserver and ui to info instead of debug, this will help to reduce log size and the redundant message.