### PR TITLE
Helm chart: added tls certificate generation toggle

### DIFF
--- a/contrib/helm/harbor/Chart.yaml
+++ b/contrib/helm/harbor/Chart.yaml
@@ -1,5 +1,5 @@
 name: harbor
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.4.0
 description: An Enterprise-class Docker Registry by VMware
 keywords:

--- a/contrib/helm/harbor/README.md
+++ b/contrib/helm/harbor/README.md
@@ -57,10 +57,24 @@ You can add `harbor.my.domain` and IP mapping in the DNS server, or in /etc/host
 
 Follow the `NOTES` section in the command output to get Harbor admin password and **add Harbor root CA into docker trusted certificates**.
 
+If you are using an external service like [cert-manager](https://github.com/jetstack/cert-manager) for generating the TLS certificates,
+you will want to disable the certificate generation by helm by setting the value `generateCertificates` to _false_. Then the ingress' annotations will be scanned
+by _cert-manager_ and the appropriate secret will get created and updated by the service.
+
+If using acme's certificates, do not forget to add the following annotation to
+your ingress.
+
+```yaml
+ingress:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+```
+
 The command deploys Harbor on the Kubernetes cluster in the default configuration.
 The [configuration](#configuration) section lists the parameters that can be configured in values.yaml or via '--set' params during installation.
 
 > **Tip**: List all releases using `helm list`
+
 
 ### Insecure Registry Mode
 
@@ -96,6 +110,7 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `harborImageTag`     | The tag for Harbor docker images | `v1.4.0` |
 | `externalDomain`       | Harbor will run on (https://`externalDomain`/). Recommend using K8s Ingress Controller FQDN as `externalDomain`, or make sure this FQDN resolves to the K8s Ingress Controller IP. | `harbor.my.domain` |
 | `insecureRegistry`     | If set to true, you don't need to set tlsCrt/tlsKey/caCrt, but must add Harbor FQDN as insecure-registries for your docker client. | `false` |
+| `generateCertificates`  | Set to false if TLS certificate will be managed by an external service | `true` |
 | `tlsCrt`               | TLS certificate to use for Harbor's https endpoint. Its CN must match `externalDomain`. | auto-generated |
 | `tlsKey`               | TLS key to use for Harbor's https endpoint | auto-generated |
 | `caCrt`                | CA Cert for self signed TLS cert | auto-generated |

--- a/contrib/helm/harbor/templates/ingress/secret.yaml
+++ b/contrib/helm/harbor/templates/ingress/secret.yaml
@@ -1,4 +1,5 @@
 {{ if not .Values.insecureRegistry }}
+{{ if .Values.generateCertificates }}
 {{ $ca := genCA "harbor-ca" 365 }}
 {{ $cert := genSignedCert .Values.externalDomain nil nil 365 $ca }}
 apiVersion: v1
@@ -12,4 +13,5 @@ data:
   tls.crt: {{ .Values.tlsCrt | default $cert.Cert | b64enc | quote }}
   tls.key: {{ .Values.tlsKey | default $cert.Key | b64enc | quote }}
   ca.crt: {{ .Values.caCrt | default $ca.Cert | b64enc | quote }}
+{{ end }}
 {{ end }}

--- a/contrib/helm/harbor/values.yaml
+++ b/contrib/helm/harbor/values.yaml
@@ -36,6 +36,7 @@ externalDomain: harbor.my.domain
 # If set to true, you don't need to set tlsCrt/tlsKey/caCrt, but must add
 # Harbor FQDN as insecure-registries for your docker client.
 insecureRegistry: false
+generateCertificates: true
 # The TLS certificate for Harbor. The common name of tlsCrt must match the externalDomain above.
 tlsCrt:
 tlsKey:


### PR DESCRIPTION
fix for https://github.com/vmware/harbor/issues/4644

default behavior is the same as before ie: auto-generated