### PR TITLE
Fix bug #4688

### DIFF
--- a/src/common/security/admiral/authcontext/authcontext.go
+++ b/src/common/security/admiral/authcontext/authcontext.go
@@ -76,7 +76,7 @@ func (a *AuthContext) GetProjectRoles(projectIDOrName interface{}) []int {
 	roles := []string{}
 	for _, project := range a.Projects {
 		p := convertProject(project)
-		if p.ProjectID == id || p.Name == name {
+		if id != 0 && p.ProjectID == id || len(name) > 0 && p.Name == name {
 			roles = append(roles, project.Roles...)
 			break
 		}


### PR DESCRIPTION
Fix bug: the user can push images although he have no permisson by checking empty value before assign permissions.