### PR TITLE
 Update security context for assign role to project group member

### DIFF
--- a/src/common/dao/dao_test.go
+++ b/src/common/dao/dao_test.go
@@ -662,7 +662,7 @@ func TestGetTotalOfProjects(t *testing.T) {
 func TestGetProjects(t *testing.T) {
 	projects, err := GetProjects(nil)
 	if err != nil {
-		t.Errorf("Error occurred in GetAllProjects: %v", err)
+		t.Errorf("Error occurred in GetProjects: %v", err)
 	}
 	if len(projects) != 2 {
 		t.Errorf("Expected length of projects is 2, but actual: %d, the projects: %+v", len(projects), projects)

--- a/src/common/dao/group/usergroup.go
+++ b/src/common/dao/group/usergroup.go
@@ -15,7 +15,10 @@
 package group
 
 import (
+	"strings"
 	"time"
+
+	"github.com/vmware/harbor/src/common"
 
 	"github.com/vmware/harbor/src/common/dao"
 	"github.com/vmware/harbor/src/common/models"
@@ -132,4 +135,21 @@ func OnBoardUserGroup(g *models.UserGroup, keyAttribute string, combinedKeyAttri
 	}
 
 	return nil
+}
+
+// GetGroupDNQueryCondition get the part of IN ('XXX', 'XXX') condition
+func GetGroupDNQueryCondition(userGroupList []*models.UserGroup) string {
+	result := make([]string, 0)
+	count := 0
+	for _, userGroup := range userGroupList {
+		if userGroup.GroupType == common.LdapGroupType {
+			result = append(result, "'"+userGroup.LdapGroupDN+"'")
+			count++
+		}
+	}
+	//No LDAP Group found
+	if count == 0 {
+		return ""
+	}
+	return strings.Join(result, ",")
 }

--- a/src/common/dao/project/projectmember.go
+++ b/src/common/dao/project/projectmember.go
@@ -30,14 +30,14 @@ func GetProjectMember(queryMember models.Member) ([]*models.Member, error) {
 	}
 
 	o := dao.GetOrmer()
-	sql := ` select a.* from ((select pm.id as id, pm.project_id as project_id, ug.id as entity_id, ug.group_name as entity_name, ug.creation_time, ug.update_time, r.name as rolename, 
+	sql := ` select a.* from (select pm.id as id, pm.project_id as project_id, ug.id as entity_id, ug.group_name as entity_name, ug.creation_time, ug.update_time, r.name as rolename, 
 		r.role_id as role, pm.entity_type as entity_type from user_group ug join project_member pm 
-		on pm.project_id = ? and ug.id = pm.entity_id join role r on pm.role = r.role_id where  pm.entity_type = 'g')
+		on pm.project_id = ? and ug.id = pm.entity_id join role r on pm.role = r.role_id where  pm.entity_type = 'g'
 		union
-		(select pm.id as id, pm.project_id as project_id, u.user_id as entity_id, u.username as entity_name, u.creation_time, u.update_time, r.name as rolename, 
+		select pm.id as id, pm.project_id as project_id, u.user_id as entity_id, u.username as entity_name, u.creation_time, u.update_time, r.name as rolename, 
 		r.role_id as role, pm.entity_type as entity_type from harbor_user u join project_member pm 
 		on pm.project_id = ? and u.user_id = pm.entity_id 
-		join role r on pm.role = r.role_id where u.deleted = false and pm.entity_type = 'u')) as a where a.project_id = ? `
+		join role r on pm.role = r.role_id where u.deleted = false and pm.entity_type = 'u') as a where a.project_id = ? `
 
 	queryParam := make([]interface{}, 1)
 	// used ProjectID already
@@ -63,7 +63,7 @@ func GetProjectMember(queryMember models.Member) ([]*models.Member, error) {
 		sql += " and a.id = ? "
 		queryParam = append(queryParam, queryMember.ID)
 	}
-	sql += ` order by a.entity_name `
+	sql += ` order by entity_name `
 	members := []*models.Member{}
 	_, err := o.Raw(sql, queryParam).QueryRows(&members)
 
@@ -120,29 +120,44 @@ func DeleteProjectMemberByID(pmid int) error {
 // SearchMemberByName search members of the project by entity_name
 func SearchMemberByName(projectID int64, entityName string) ([]*models.Member, error) {
 	o := dao.GetOrmer()
-	sql := `(select pm.id, pm.project_id, 
+	sql := `select pm.id, pm.project_id, 
 	               u.username as entity_name, 
 	               r.name as rolename,
 			       pm.role, pm.entity_id, pm.entity_type 
 			  from project_member pm
          left join harbor_user u on pm.entity_id = u.user_id and pm.entity_type = 'u'
 		 left join role r on pm.role = r.role_id
-			 where u.deleted = false and pm.project_id = ? and u.username like ? order by entity_name )
+			 where u.deleted = false and pm.project_id = ? and u.username like ? 
 			union
-		   (select pm.id, pm.project_id, 
+		   select pm.id, pm.project_id, 
 			       ug.group_name as entity_name, 
 				   r.name as rolename,
 				   pm.role, pm.entity_id, pm.entity_type 
 		      from project_member pm
 	     left join user_group ug on pm.entity_id = ug.id and pm.entity_type = 'g'
 	     left join role r on pm.role = r.role_id
-		     where pm.project_id = ? and ug.group_name like ? order by entity_name ) `
+			 where pm.project_id = ? and ug.group_name like ? 
+			 order by entity_name  `
 	queryParam := make([]interface{}, 4)
 	queryParam = append(queryParam, projectID)
 	queryParam = append(queryParam, "%"+dao.Escape(entityName)+"%")
 	queryParam = append(queryParam, projectID)
 	queryParam = append(queryParam, "%"+dao.Escape(entityName)+"%")
 	members := []*models.Member{}
+	log.Debugf("Query sql: %v", sql)
 	_, err := o.Raw(sql, queryParam).QueryRows(&members)
 	return members, err
+}
+
+// GetRolesByGroup -- Query group roles
+func GetRolesByGroup(projectID int64, groupDNCondition string) []int {
+	var roles []int
+	o := dao.GetOrmer()
+	sql := `select role from project_member pm 
+	left join user_group ug on pm.project_id = ?
+	where ug.group_type = 1 and ug.ldap_group_dn in (` + groupDNCondition + `)`
+	if _, err := o.Raw(sql, projectID).QueryRows(&roles); err != nil {
+		return roles
+	}
+	return roles
 }

--- a/src/common/dao/project_test.go
+++ b/src/common/dao/project_test.go
@@ -103,9 +103,9 @@ func Test_projectQueryConditions(t *testing.T) {
 			args{query: &models.ProjectQueryParam{ProjectIDs: []int64{2, 3}, Owner: "admin", Name: "sample", Member: &models.MemberQuery{Name: "name", Role: 1}, Pagination: &models.Pagination{Page: 1, Size: 20}}},
 			` from project as p join harbor_user u1
 					on p.owner_id = u1.user_id join project_member pm
-					on p.project_id = pm.project_id
+					on p.project_id = pm.project_id and pm.entity_type = 'u'
 					join harbor_user u2
-					on pm.entity_id=u2.user_id where p.deleted=false and u1.username=? and p.name like ? and u2.username=? and pm.role = ? and p.project_id in ( ?,? ) order by p.name limit ? offset ?`,
+					on pm.entity_id=u2.user_id where p.deleted=false and u1.username=? and p.name like ? and u2.username=? and pm.role = ? and p.project_id in ( ?,? )`,
 			[]interface{}{1, []int64{2, 3}, 20, 0}},
 	}
 	for _, tt := range tests {
@@ -113,6 +113,124 @@ func Test_projectQueryConditions(t *testing.T) {
 			got, _ := projectQueryConditions(tt.args.query)
 			if strings.TrimSpace(got) != strings.TrimSpace(tt.want) {
 				t.Errorf("projectQueryConditions() got = %v\n, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetGroupProjects(t *testing.T) {
+	prepareGroupTest()
+	query := &models.ProjectQueryParam{Member: &models.MemberQuery{Name: "sample_group"}}
+	type args struct {
+		groupDNCondition string
+		query            *models.ProjectQueryParam
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantSize int
+		wantErr  bool
+	}{
+		{"Verify correct sql", args{groupDNCondition: "'cn=harbor_user,dc=example,dc=com'", query: query}, 1, false},
+		{"Verify missed sql", args{groupDNCondition: "'cn=another_user,dc=example,dc=com'", query: query}, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetGroupProjects(tt.args.groupDNCondition, tt.args.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetGroupProjects() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != tt.wantSize {
+				t.Errorf("GetGroupProjects() = %v, want %v", got, tt.wantSize)
+			}
+		})
+	}
+}
+
+func prepareGroupTest() {
+	initSqls := []string{
+		`insert into user_group (group_name, group_type, ldap_group_dn) values ('harbor_group_01', 1, 'cn=harbor_user,dc=example,dc=com')`,
+		`insert into harbor_user (username, email, password, realname) values ('sample01', 'sample01@example.com', 'harbor12345', 'sample01')`,
+		`insert into project (name, owner_id) values ('group_project', 1)`,
+		`insert into project (name, owner_id) values ('group_project_private', 1)`,
+		`insert into project_metadata (project_id, name, value) values ((select project_id from project where name = 'group_project'), 'public', 'false')`,
+		`insert into project_metadata (project_id, name, value) values ((select project_id from project where name = 'group_project_private'), 'public', 'false')`,
+		`insert into project_member (project_id, entity_id, entity_type, role) values ((select project_id from project where name = 'group_project'), (select id from user_group where group_name = 'harbor_group_01'),'g', 2)`,
+	}
+
+	clearSqls := []string{
+		`delete from project_metadata where project_id in (select project_id from project where name in ('group_project', 'group_project_private'))`,
+		`delete from project where name in ('group_project', 'group_project_private')`,
+		`delete from project_member where project_id in (select project_id from project where name in ('group_project', 'group_project_private'))`,
+		`delete from user_group where group_name = 'harbor_group_01'`,
+		`delete from harbor_user where username = 'sample01'`,
+	}
+	PrepareTestData(clearSqls, initSqls)
+}
+
+func TestGetTotalGroupProjects(t *testing.T) {
+	prepareGroupTest()
+	query := &models.ProjectQueryParam{Member: &models.MemberQuery{Name: "sample_group"}}
+	type args struct {
+		groupDNCondition string
+		query            *models.ProjectQueryParam
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{"Verify correct sql", args{groupDNCondition: "'cn=harbor_user,dc=example,dc=com'", query: query}, 1, false},
+		{"Verify missed sql", args{groupDNCondition: "'cn=another_user,dc=example,dc=com'", query: query}, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetTotalGroupProjects(tt.args.groupDNCondition, tt.args.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetTotalGroupProjects() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetTotalGroupProjects() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetRolesByLDAPGroup(t *testing.T) {
+	prepareGroupTest()
+	project, err := GetProjectByName("group_project")
+	if err != nil {
+		t.Errorf("Error occurred when Get project by name: %v", err)
+	}
+	privateProject, err := GetProjectByName("group_project_private")
+	if err != nil {
+		t.Errorf("Error occurred when Get project by name: %v", err)
+	}
+	type args struct {
+		projectID        int64
+		groupDNCondition string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantSize int
+		wantErr  bool
+	}{
+		{"Check normal", args{project.ProjectID, "'cn=harbor_user,dc=example,dc=com'"}, 1, false},
+		{"Check non exist", args{privateProject.ProjectID, "'cn=not_harbor_user,dc=example,dc=com'"}, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetRolesByLDAPGroup(tt.args.projectID, tt.args.groupDNCondition)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TestGetRolesByLDAPGroup() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != tt.wantSize {
+				t.Errorf("TestGetRolesByLDAPGroup() = %v, want %v", len(got), tt.wantSize)
 			}
 		})
 	}

--- a/src/common/dao/testutils.go
+++ b/src/common/dao/testutils.go
@@ -116,3 +116,17 @@ func PrepareTestData(clearSqls []string, initSqls []string) {
 		}
 	}
 }
+
+// ArrayEqual ...
+func ArrayEqual(arrayA, arrayB []int) bool {
+	if len(arrayA) != len(arrayB) {
+		return false
+	}
+	size := len(arrayA)
+	for i := 0; i < size; i++ {
+		if arrayA[i] != arrayB[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/src/common/models/project.go
+++ b/src/common/models/project.go
@@ -147,8 +147,9 @@ type ProjectQueryParam struct {
 
 // MemberQuery fitler by member's username and role
 type MemberQuery struct {
-	Name string // the username of member
-	Role int    // the role of the member has to the project
+	Name      string       // the username of member
+	Role      int          // the role of the member has to the project
+	GroupList []*UserGroup // the group list of current user
 }
 
 // Pagination ...

--- a/src/common/models/user.go
+++ b/src/common/models/user.go
@@ -35,11 +35,12 @@ type User struct {
 	//to it.
 	Role int `orm:"-" json:"role_id"`
 	//	RoleList     []Role `json:"role_list"`
-	HasAdminRole bool      `orm:"column(sysadmin_flag)" json:"has_admin_role"`
-	ResetUUID    string    `orm:"column(reset_uuid)" json:"reset_uuid"`
-	Salt         string    `orm:"column(salt)" json:"-"`
-	CreationTime time.Time `orm:"column(creation_time)" json:"creation_time"`
-	UpdateTime   time.Time `orm:"column(update_time)" json:"update_time"`
+	HasAdminRole bool         `orm:"column(sysadmin_flag)" json:"has_admin_role"`
+	ResetUUID    string       `orm:"column(reset_uuid)" json:"reset_uuid"`
+	Salt         string       `orm:"column(salt)" json:"-"`
+	CreationTime time.Time    `orm:"column(creation_time)" json:"creation_time"`
+	UpdateTime   time.Time    `orm:"column(update_time)" json:"update_time"`
+	GroupList    []*UserGroup `orm:"-" json:"-"`
 }
 
 // UserQuery ...

--- a/src/common/security/admiral/context_test.go
+++ b/src/common/security/admiral/context_test.go
@@ -13,5 +13,3 @@
 // limitations under the License.
 
 package admiral
-
-// TODO add test cases

--- a/src/common/security/context.go
+++ b/src/common/security/context.go
@@ -34,6 +34,8 @@ type Context interface {
 	HasWritePerm(projectIDOrName interface{}) bool
 	// HasAllPerm returns whether the user has all permissions to the project
 	HasAllPerm(projectIDOrName interface{}) bool
+	//Get current user's all project
 	GetMyProjects() ([]*models.Project, error)
+	//Get user's role in provided project
 	GetProjectRoles(projectIDOrName interface{}) []int
 }

--- a/src/ui/api/project.go
+++ b/src/ui/api/project.go
@@ -347,19 +347,16 @@ func (p *ProjectAPI) List() {
 					return
 				}
 				projects = append(projects, pros...)
-
-				mps, err := p.ProjectMgr.List(&models.ProjectQueryParam{
-					Member: &models.MemberQuery{
-						Name: p.SecurityCtx.GetUsername(),
-					},
-				})
+				mps, err := p.SecurityCtx.GetMyProjects()
 				if err != nil {
 					p.HandleInternalServerError(fmt.Sprintf("failed to list projects: %v", err))
 					return
 				}
-				projects = append(projects, mps.Projects...)
+				projects = append(projects, mps...)
 			}
 		}
+		//Query projects by user group
+
 		if projects != nil {
 			projectIDs := []int64{}
 			for _, project := range projects {

--- a/src/ui/auth/ldap/ldap_test.go
+++ b/src/ui/auth/ldap/ldap_test.go
@@ -109,7 +109,7 @@ func TestMain(m *testing.M) {
 
 	//Extract to test utils
 	initSqls := []string{
-		"insert into user (username, email, password, realname)  values ('member_test_01', 'member_test_01@example.com', '123456', 'member_test_01')",
+		"insert into harbor_user (username, email, password, realname)  values ('member_test_01', 'member_test_01@example.com', '123456', 'member_test_01')",
 		"insert into project (name, owner_id) values ('member_test_01', 1)",
 		"insert into user_group (group_name, group_type, group_property) values ('test_group_01', 1, 'CN=harbor_users,OU=sample,OU=vmware,DC=harbor,DC=com')",
 		"update project set owner_id = (select user_id from harbor_user where username = 'member_test_01') where name = 'member_test_01'",

--- a/tests/testprepare.sh
+++ b/tests/testprepare.sh
@@ -7,7 +7,11 @@ cp make/common/config/ui/private_key.pem /etc/ui/
 
 mkdir src/ui/conf
 cp make/common/config/ui/app.conf src/ui/conf/
-IP=`ip addr s eth0 |grep "inet "|awk '{print $2}' |awk -F "/" '{print $1}'`
+if [ "$(uname)" == "Darwin" ]; then
+	IP=`ifconfig en0 | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'`
+else 
+        IP=`ip addr s eth0 |grep "inet "|awk '{print $2}' |awk -F "/" '{print $1}'`
+fi
 echo "server ip is "$IP
 sed -i -r "s/POSTGRESQL_HOST=postgresql/POSTGRESQL_HOST=$IP/" make/common/config/adminserver/env
 sed -i -r "s|REGISTRY_URL=http://registry:5000|REGISTRY_URL=http://$IP:5000|" make/common/config/adminserver/env


### PR DESCRIPTION
The project list will contain all public projects, user is a member of this project, or user is in the group which is a member of this projects.
Change the behaviour of user roles, if the user is not a member of this project, then return the user's groups role of current project