### PR TITLE
Return the logger.Interface instead of the pointer of logger to avoid nil checking issue

### DIFF
--- a/src/jobservice/job/impl/logger/job_logger.go
+++ b/src/jobservice/job/impl/logger/job_logger.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/vmware/harbor/src/common/utils/log"
+	"github.com/vmware/harbor/src/jobservice/logger"
 )
 
 //JobLogger is an implementation of logger.Interface.
@@ -16,7 +17,7 @@ type JobLogger struct {
 
 //New logger
 //nil might be returned
-func New(logPath string, level string) *JobLogger {
+func New(logPath string, level string) logger.Interface {
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil


### PR DESCRIPTION
An interface value is nil only if the inner value and type are both unset, (nil, nil). In particular, a nil interface will always hold a nil type. If we store a nil pointer of type *int inside an interface value, the inner type will be *int regardless of the value of the pointer: (*int, nil). Such an interface value will therefore be non-nil even when the pointer inside is nil.