### PR TITLE
Cherry-pick: Fix mis-interpretation of severity in Clair

### DIFF
--- a/src/common/models/pro_meta.go
+++ b/src/common/models/pro_meta.go
@@ -29,6 +29,7 @@ const (
 	SeverityLow               = "low"
 	SeverityMedium            = "medium"
 	SeverityHigh              = "high"
+	SeverityCritical          = "critical"
 )
 
 // ProjectMetadata holds the metadata of a project.

--- a/src/common/utils/clair/utils.go
+++ b/src/common/utils/clair/utils.go
@@ -15,10 +15,10 @@
 package clair
 
 import (
+	"fmt"
 	"github.com/vmware/harbor/src/common/dao"
 	"github.com/vmware/harbor/src/common/models"
 	"github.com/vmware/harbor/src/common/utils/log"
-	"fmt"
 	"strings"
 )
 
@@ -34,7 +34,7 @@ func ParseClairSev(clairSev string) models.Severity {
 		return models.SevLow
 	case models.SeverityMedium:
 		return models.SevMedium
-	case models.SeverityHigh:
+	case models.SeverityHigh, models.SeverityCritical:
 		return models.SevHigh
 	default:
 		return models.SevUnknown

--- a/src/common/utils/clair/utils_test.go
+++ b/src/common/utils/clair/utils_test.go
@@ -32,6 +32,7 @@ func TestParseServerity(t *testing.T) {
 		"LOW":        models.SevLow,
 		"Medium":     models.SevMedium,
 		"high":       models.SevHigh,
+		"Critical":   models.SevHigh,
 	}
 	for k, v := range in {
 		assert.Equal(v, ParseClairSev(k))


### PR DESCRIPTION
Currently "Critical" vulnerablity is treated as "Unknown" in Harbor.
This commit provides a quickfix that it will be interpret as "High".  In
future, we should consider introduce "Critical" and enable UI to handle
it to be more consistent with CVSS spec.