### PR TITLE
Return 404 if user is not found

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -513,7 +513,7 @@ paths:
         '403':
           description: User in session does not have permission to the project.
         '404':
-          description: Project does not exist.
+          description: Project does not exist, or the username does not found, or the user group does not found.
         '500':
           description: Unexpected internal errors.  
   '/projects/{project_id}/members/{mid}':

--- a/src/ui/api/projectmember.go
+++ b/src/ui/api/projectmember.go
@@ -122,6 +122,10 @@ func (pma *ProjectMemberAPI) Post() {
 	var request models.MemberReq
 	pma.DecodeJSONReq(&request)
 	pmid, err := AddOrUpdateProjectMember(projectID, request)
+	if err == auth.ErrorGroupNotExist || err == auth.ErrorUserNotExist {
+		pma.HandleNotFound(fmt.Sprintf("Failed to add project member, error: %v", err))
+		return
+	}
 	if err != nil {
 		pma.HandleInternalServerError(fmt.Sprintf("Failed to add project member, error: %v", err))
 		return

--- a/src/ui/api/projectmember_test.go
+++ b/src/ui/api/projectmember_test.go
@@ -121,6 +121,20 @@ func TestProjectMemberAPI_Post(t *testing.T) {
 				bodyJSON: &models.MemberReq{
 					Role: 1,
 					MemberUser: models.User{
+						Username: "notexistuser",
+					},
+				},
+				credential: admin,
+			},
+			code: http.StatusNotFound,
+		},
+		&codeCheckingCase{
+			request: &testingRequest{
+				method: http.MethodPost,
+				url:    "/api/projects/1/members",
+				bodyJSON: &models.MemberReq{
+					Role: 1,
+					MemberUser: models.User{
 						UserID: 0,
 					},
 				},

--- a/src/ui/auth/authenticator.go
+++ b/src/ui/auth/authenticator.go
@@ -31,6 +31,12 @@ const frozenTime time.Duration = 1500 * time.Millisecond
 
 var lock = NewUserLock(frozenTime)
 
+// ErrorUserNotExist ...
+var ErrorUserNotExist = errors.New("User does not exist")
+
+// ErrorGroupNotExist ...
+var ErrorGroupNotExist = errors.New("Group does not exist")
+
 //ErrAuth is the type of error to indicate a failed authentication due to user's error.
 type ErrAuth struct {
 	details string
@@ -200,6 +206,9 @@ func SearchGroup(groupKey string) (*models.UserGroup, error) {
 // SearchAndOnBoardUser ... Search user and OnBoard user, if user exist, return the ID of current user.
 func SearchAndOnBoardUser(username string) (int, error) {
 	user, err := SearchUser(username)
+	if user == nil {
+		return 0, ErrorUserNotExist
+	}
 	if err != nil {
 		return 0, err
 	}
@@ -215,6 +224,9 @@ func SearchAndOnBoardUser(username string) (int, error) {
 // SearchAndOnBoardGroup ... if altGroupName is not empty, take the altGroupName as groupName in harbor DB
 func SearchAndOnBoardGroup(groupKey, altGroupName string) (int, error) {
 	userGroup, err := SearchGroup(groupKey)
+	if userGroup == nil {
+		return 0, ErrorGroupNotExist
+	}
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
When adding a project member, if the user/group is not found in database or LDAP, it should return 404 instead of 500 so that the UI can display error message