### PR TITLE
Modify unique constraint of table harbor_label in pgsql

### DIFF
--- a/make/photon/db/postgresql/registry.sql
+++ b/make/photon/db/postgresql/registry.sql
@@ -309,7 +309,7 @@ create table harbor_label (
  creation_time timestamp default 'now'::timestamp,
  update_time timestamp default 'now'::timestamp,
  PRIMARY KEY(id),
- CONSTRAINT unique_name_and_scope UNIQUE (name,scope)
+ CONSTRAINT unique_label UNIQUE (name,scope, project_id)
  );
 
 CREATE TRIGGER harbor_label_update_time_at_modtime BEFORE UPDATE ON harbor_label FOR EACH ROW EXECUTE PROCEDURE update_update_time_at_column();


### PR DESCRIPTION
Add unique constraint to column name, scope and project_id of table harbor_label to make creating same name labels under different projects valid