### PR TITLE
Collect log of redis - cherrypick to 1.5 branch

### DIFF
--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -119,6 +119,13 @@ services:
       - /data/redis:/data
     networks:
       - harbor
+    depends_on:
+      - log
+    logging:
+      driver: "syslog"
+      options:  
+        syslog-address: "tcp://127.0.0.1:1514"
+        tag: "redis"
   proxy:
     image: vmware/nginx-photon:__nginx_version__
     container_name: nginx

--- a/make/photon/redis/redis.conf
+++ b/make/photon/redis/redis.conf
@@ -168,7 +168,7 @@ loglevel notice
 # Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile "/var/log/redis/redis.log"
+logfile ""
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.


### PR DESCRIPTION
Previously the log file was set to a hard coded file, but given this
redis should run in container, the update is made to have the process
output log messages to standard output, and redirect it to syslog in
docker-compose template.