### PR TITLE
Add default value for redis_url in v1.5.0 migrator

### DIFF
--- a/tools/migration/cfg/migrator_1_5_0/__init__.py
+++ b/tools/migration/cfg/migrator_1_5_0/__init__.py
@@ -10,7 +10,7 @@ default = {
     'db_host':'mysql',
     'db_port':'3306',
     'db_user':'root',
-    'redis_url':'',
+    'redis_url':'redis:6379',
     'clair_db_host':'postgres',
     'clair_db_port':'5432',
     'clair_db_username':'postgres',


### PR DESCRIPTION
as the default value of redis_url in the harbor.cfg has changed, so we need to leverage the value into the migrator