### PR TITLE
Add redis cache support for registry pod

### DIFF
--- a/contrib/helm/harbor/templates/registry/registry-cm.yaml
+++ b/contrib/helm/harbor/templates/registry/registry-cm.yaml
@@ -24,6 +24,10 @@ data:
           enabled: false
       delete:
         enabled: true
+    {{- if .Values.registry.redis }}
+    redis:
+{{ toYaml .Values.registry.redis | indent 6 }}
+    {{- end }}
     http:
       addr: :5000
       # set via environment variable

--- a/contrib/helm/harbor/values.yaml
+++ b/contrib/helm/harbor/values.yaml
@@ -254,7 +254,12 @@ registry:
   #  requests:
   #    memory: 256Mi
   #    cpu: 100m
+  ## Enable the redis caching in the registry
+  #redis:
+  #  addr: "redis-host:6379"
+  #  db: 2
 
+  
 clair:
   enabled: true
   image:


### PR DESCRIPTION
Just a simple add on to allow using redis for blob caching in the registry.

Currently this would be an existing redis...