### PR TITLE
Modify harbor log files name to align with latest change

### DIFF
--- a/tests/resources/Nightly-Util.robot
+++ b/tests/resources/Nightly-Util.robot
@@ -51,11 +51,9 @@ Collect Logs
     SSHLibrary.Get File  /var/log/harbor/registry.log
     SSHLibrary.Get File  /var/log/harbor/proxy.log
     SSHLibrary.Get File  /var/log/harbor/adminserver.log  
-    SSHLibrary.Get File  /var/log/harbor/clair-db.log  
     SSHLibrary.Get File  /var/log/harbor/clair.log  
     SSHLibrary.Get File  /var/log/harbor/jobservice.log  
-    SSHLibrary.Get File  /var/log/harbor/mysql.log
-    SSHLibrary.Get File  /var/log/harbor/notary-db.log
+    SSHLibrary.Get File  /var/log/harbor/postgresql.log
     SSHLibrary.Get File  /var/log/harbor/notary-server.log
     SSHLibrary.Get File  /var/log/harbor/notary-signer.log
     Run  rename 's/^/${ip}/' *.log


### PR DESCRIPTION
Remove the notary-db and clair-db logs files, and change the mysql.log to postgresql.log. There changes are align with the Harbor DB migration, otherwise, the nightly will fail by collecting logs in the tear down phase. 