### PR TITLE
Dump log of shutting down harbor in CI

### DIFF
--- a/tests/resources/Harbor-Util.robot
+++ b/tests/resources/Harbor-Util.robot
@@ -51,6 +51,7 @@ Down Harbor
     [Arguments]  ${with_notary}=true  ${with_clair}=true
     ${rc}  ${output}=  Run And Return Rc And Output  echo "Y" | make down -e NOTARYFLAG=${with_notary} CLAIRFLAG=${with_clair}
     Log  ${rc}
+    Log  ${output}
     Should Be Equal As Integers  ${rc}  0
 
 Package Harbor Offline


### PR DESCRIPTION
To investigate the failure on LDAP test case in drone CI, it needs to log the output of shutting down Harbor, then to analyse the root cause. 
