### PR TITLE
Update swagger.yaml to add ldap group config parameters

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3470,6 +3470,18 @@ definitions:
       ldap_timeout:
         type: integer
         description: timeout in seconds for connection to LDAP server.
+      ldap_group_attribute_name:
+        type: string
+        description: The attribute which is used as identity of the LDAP group, default is cn.
+      ldap_group_base_dn:
+        type: string
+        description: The base DN to search LDAP group.
+      ldap_group_search_filter:
+        type: string
+        description: The filter to search the ldap group.
+      ldap_group_search_scope:
+        type: integer
+        description: The scope to search ldap. '0-LDAP_SCOPE_BASE, 1-LDAP_SCOPE_ONELEVEL, 2-LDAP_SCOPE_SUBTREE'
       project_creation_restriction:
         type: string
         description: >-


### PR DESCRIPTION
Parameters include:
ldap_group_attribute_name
ldap_group_base_dn
ldap_group_search_filter
ldap_group_search_scope

**Test**
1.Prepare swagger env by https://github.com/vmware/harbor/blob/10199c10efe5dff3479ddc174e287b34cb39b306/docs/configure_swagger.md

2.Testing the ldap_group related configuration update/reset with payload
{
"ldap_group_attribute_name":"uid",
"ldap_group_base_dn":"ou=group,dc=example,dc=com",
"ldap_group_search_filter":"objectclass=groupOfNames",
"ldap_group_search_scope":1
}
3. Check the get API can get the updated value.
4. Check the reset API can reset it to the default value.