### PR TITLE
Add package mariadb-server-galera on image photon/mariadb

### DIFF
--- a/make/photon/mariadb/Dockerfile
+++ b/make/photon/mariadb/Dockerfile
@@ -5,7 +5,7 @@ FROM vmware/photon:1.0
 RUN tdnf distro-sync -y \
     && tdnf install -y sed shadow procps-ng gawk gzip sudo net-tools >> /dev/null\
     && groupadd -r -g 10000 mysql && useradd --no-log-init -r -g 10000 -u 10000 mysql \
-    && tdnf install -y mariadb-server mariadb >> /dev/null\
+    && tdnf install -y mariadb-server mariadb-server-galera mariadb >> /dev/null\
     && mkdir /docker-entrypoint-initdb.d /docker-entrypoint-updatedb.d \
     && rm -fr /var/lib/mysql \
     && mkdir -p /var/lib/mysql /var/run/mysqld \


### PR DESCRIPTION
This commit add the binaries needed by mariadb cluster.