### PR TITLE
Sync user info after UAA user is logged in - cherry pick to 1.5 branch

### DIFF
--- a/src/ui/auth/uaa/uaa.go
+++ b/src/ui/auth/uaa/uaa.go
@@ -68,6 +68,12 @@ func (u *Auth) OnBoardUser(user *models.User) error {
 	if len(user.Password) == 0 {
 		user.Password = "1234567ab"
 	}
+	fillEmailRealName(user)
+	user.Comment = "From UAA"
+	return dao.OnBoardUser(user)
+}
+
+func fillEmailRealName(user *models.User) {
 	if len(user.Realname) == 0 {
 		user.Realname = user.Username
 	}
@@ -75,8 +81,6 @@ func (u *Auth) OnBoardUser(user *models.User) error {
 		//TODO: handle the case when user.Username itself is an email address.
 		user.Email = user.Username + "@uaa.placeholder"
 	}
-	user.Comment = "From UAA"
-	return dao.OnBoardUser(user)
 }
 
 // PostAuthenticate will check if user exists in DB, if not on Board user, if he does, update the profile.
@@ -88,12 +92,9 @@ func (u *Auth) PostAuthenticate(user *models.User) error {
 	if dbUser == nil {
 		return u.OnBoardUser(user)
 	}
-	if user.Email != "" {
-		dbUser.Email = user.Email
-	}
-	if user.Realname != "" {
-		dbUser.Realname = user.Realname
-	}
+	user.UserID = dbUser.UserID
+	user.HasAdminRole = dbUser.HasAdminRole
+	fillEmailRealName(user)
 	if err2 := dao.ChangeUserProfile(*user, "Email", "Realname"); err2 != nil {
 		log.Warningf("Failed to update user profile, user: %s, error: %v", user.Username, err2)
 	}

--- a/src/ui/auth/uaa/uaa_test.go
+++ b/src/ui/auth/uaa/uaa_test.go
@@ -166,19 +166,33 @@ func TestPostAuthenticate(t *testing.T) {
 		Username: "test",
 	}
 	err := auth.PostAuthenticate(um)
+	//need a new user model to simulate a login case...
+	um2 := &models.User{
+		Username: "test",
+	}
 	assert.Nil(err)
 	user, _ := dao.GetUser(models.User{Username: "test"})
 	assert.Equal("test@uaa.placeholder", user.Email)
-	um.Email = "newEmail@new.com"
-	um.Realname = "newName"
-	err2 := auth.PostAuthenticate(um)
+	um2.Email = "newEmail@new.com"
+	um2.Realname = "newName"
+	err2 := auth.PostAuthenticate(um2)
+	assert.Equal(user.UserID, um2.UserID)
 	assert.Nil(err2)
 	user2, _ := dao.GetUser(models.User{Username: "test"})
 	assert.Equal("newEmail@new.com", user2.Email)
 	assert.Equal("newName", user2.Realname)
-	err3 := dao.ClearTable(models.UserTable)
+	//need a new user model to simulate a login case...
+	um3 := &models.User{
+		Username: "test",
+	}
+	err3 := auth.PostAuthenticate(um3)
 	assert.Nil(err3)
-
+	user3, _ := dao.GetUser(models.User{Username: "test"})
+	assert.Equal(user3.UserID, um3.UserID)
+	assert.Equal("test@uaa.placeholder", user3.Email)
+	assert.Equal("test", user3.Realname)
+	err4 := dao.ClearTable(models.UserTable)
+	assert.Nil(err4)
 }
 
 func TestSearchUser(t *testing.T) {


### PR DESCRIPTION
This is a fix to #4895.
Currently the user data will not be populated correctly after a user in
UAA is logged in.  This problem is fixed in this commit.