### PR TITLE
Fix issue of import LDAP user 404 message

### DIFF
--- a/src/ui/api/ldap.go
+++ b/src/ui/api/ldap.go
@@ -118,7 +118,8 @@ func (l *LdapAPI) ImportUser() {
 	}
 
 	if len(ldapFailedImportUsers) > 0 {
-		l.HandleNotFound("Import LDAP user is not found")
+		//Some user require json format response.
+		l.HandleNotFound("")
 		l.Data["json"] = ldapFailedImportUsers
 		l.ServeJSON()
 		return


### PR DESCRIPTION
Some user requires return json format message in 404 when importing not exist LDAP users