### PR TITLE
remove unused upstream

### DIFF
--- a/make/common/templates/nginx/nginx.http.conf
+++ b/make/common/templates/nginx/nginx.http.conf
@@ -12,11 +12,6 @@ http {
   # this is necessary for us to be able to disable request buffering in all cases
   proxy_http_version 1.1;
 
-
-  upstream registry {
-    server registry:5000;
-  }
-
   upstream ui {
     server ui:8080;
   }

--- a/make/common/templates/nginx/nginx.https.conf
+++ b/make/common/templates/nginx/nginx.https.conf
@@ -13,10 +13,6 @@ http {
   # this is necessary for us to be able to disable request buffering in all cases
   proxy_http_version 1.1;
 
-  upstream registry {
-    server registry:5000;
-  }
-
   upstream ui {
     server ui:8080;
   }


### PR DESCRIPTION
this removes the registry upstream in nginx configuration (it is unused since 785298e6b).