### PR TITLE
Fix 'xxx' is not a function err

### DIFF
--- a/src/ui_ng/lib/package.json
+++ b/src/ui_ng/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "harbor-ui",
-    "version": "0.7.18-dev.8",
+    "version": "0.7.19-dev.3",
     "description": "Harbor shared UI components based on Clarity and Angular4",
     "author": "VMware",
     "module": "index.js",

--- a/src/ui_ng/lib/src/endpoint/endpoint.component.ts
+++ b/src/ui_ng/lib/src/endpoint/endpoint.component.ts
@@ -19,10 +19,14 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef
 } from "@angular/core";
+import { Subscription } from "rxjs/Subscription";
+import { Observable } from "rxjs/Observable";
+import "rxjs/add/observable/forkJoin";
+import { TranslateService } from "@ngx-translate/core";
+import { Comparator } from "clarity-angular";
+
 import { Endpoint } from "../service/interface";
 import { EndpointService } from "../service/endpoint.service";
-
-import { TranslateService } from "@ngx-translate/core";
 
 import { ErrorHandler } from "../error-handler/index";
 
@@ -36,18 +40,14 @@ import {
   ConfirmationButtons
 } from "../shared/shared.const";
 
-import { Subscription } from "rxjs/Subscription";
-
 import { CreateEditEndpointComponent } from "../create-edit-endpoint/create-edit-endpoint.component";
-
 import { toPromise, CustomComparator } from "../utils";
 
-import { Comparator } from "clarity-angular";
 import {
   BatchInfo,
   BathInfoChanges
 } from "../confirmation-dialog/confirmation-batch-message";
-import { Observable } from "rxjs/Observable";
+
 
 @Component({
   selector: "hbr-endpoint",

--- a/src/ui_ng/lib/src/list-replication-rule/list-replication-rule.component.ts
+++ b/src/ui_ng/lib/src/list-replication-rule/list-replication-rule.component.ts
@@ -25,6 +25,7 @@ import {
   SimpleChanges
 } from "@angular/core";
 import { Observable } from "rxjs/Observable";
+import "rxjs/add/observable/forkJoin";
 import { Comparator } from "clarity-angular";
 import { TranslateService } from "@ngx-translate/core";
 

--- a/src/ui_ng/lib/src/replication/replication.component.ts
+++ b/src/ui_ng/lib/src/replication/replication.component.ts
@@ -20,7 +20,11 @@ import {
   OnDestroy,
   EventEmitter
 } from "@angular/core";
-
+import { Comparator, State } from "clarity-angular";
+import { Observable } from "rxjs/Observable";
+import { Subscription } from "rxjs/Subscription";
+import 'rxjs/add/observable/forkJoin';
+import 'rxjs/add/observable/timer';
 import { TranslateService } from "@ngx-translate/core";
 
 import { ListReplicationRuleComponent } from "../list-replication-rule/list-replication-rule.component";
@@ -44,12 +48,8 @@ import {
   calculatePage
 } from "../utils";
 
-import { Comparator } from "clarity-angular";
-
 import { JobLogViewerComponent } from "../job-log-viewer/index";
-import { State } from "clarity-angular";
-import { Observable } from "rxjs/Observable";
-import { Subscription } from "rxjs/Subscription";
+
 import {
   ConfirmationTargets,
   ConfirmationButtons,

--- a/src/ui_ng/lib/src/repository-gridview/repository-gridview.component.ts
+++ b/src/ui_ng/lib/src/repository-gridview/repository-gridview.component.ts
@@ -12,6 +12,7 @@ import {
 } from "@angular/core";
 import { Router } from "@angular/router";
 import { Observable } from "rxjs/Observable";
+import "rxjs/add/observable/forkJoin";
 import { TranslateService } from "@ngx-translate/core";
 import { Comparator, State } from "clarity-angular";
 

--- a/src/ui_ng/lib/src/service/project.service.ts
+++ b/src/ui_ng/lib/src/service/project.service.ts
@@ -2,7 +2,9 @@ import { Observable } from "rxjs/Observable";
 import { Injectable, Inject } from "@angular/core";
 import { Http } from "@angular/http";
 import "rxjs/add/observable/of";
-
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/observable/throw';
 import { SERVICE_CONFIG, IServiceConfig } from "../service.config";
 import { Project } from "../project-policy-config/project";
 import { ProjectPolicy } from "../project-policy-config/project-policy-config.component";

--- a/src/ui_ng/lib/src/tag/tag.component.ts
+++ b/src/ui_ng/lib/src/tag/tag.component.ts
@@ -21,6 +21,11 @@ import {
   ChangeDetectorRef,
   ElementRef, AfterViewInit
 } from "@angular/core";
+import {Subject} from "rxjs/Subject";
+import {Observable} from "rxjs/Observable";
+import "rxjs/add/observable/forkJoin";
+import { TranslateService } from "@ngx-translate/core";
+import { State, Comparator } from "clarity-angular";
 
 import { TagService, VulnerabilitySeverity, RequestQueryParams } from "../service/index";
 import { ErrorHandler } from "../error-handler/error-handler";
@@ -48,14 +53,12 @@ import {
   clone,
 } from "../utils";
 
-import { TranslateService } from "@ngx-translate/core";
 
-import { State, Comparator } from "clarity-angular";
 import {CopyInputComponent} from "../push-image/copy-input.component";
 import {BatchInfo, BathInfoChanges} from "../confirmation-dialog/confirmation-batch-message";
-import {Observable} from "rxjs/Observable";
+
 import {LabelService} from "../service/label.service";
-import {Subject} from "rxjs/Subject";
+
 export interface LabelState {
   iconsShow: boolean;
   label: Label;

--- a/src/ui_ng/lib/src/vulnerability-scanning/result-bar-chart.component.ts
+++ b/src/ui_ng/lib/src/vulnerability-scanning/result-bar-chart.component.ts
@@ -6,6 +6,8 @@ import {
     ChangeDetectorRef,
     ViewChild
 } from '@angular/core';
+import { Observable, Subscription } from 'rxjs/Rx';
+import "rxjs/add/observable/timer";
 
 import { VULNERABILITY_SCAN_STATUS } from '../utils';
 import {
@@ -16,7 +18,6 @@ import {
 } from '../service/index';
 import { ErrorHandler } from '../error-handler/index';
 import { toPromise } from '../utils';
-import { Observable, Subscription } from 'rxjs/Rx';
 import { ChannelService } from '../channel/index';
 import { JobLogViewerComponent } from '../job-log-viewer/index';
 

--- a/src/ui_ng/package.json
+++ b/src/ui_ng/package.json
@@ -32,7 +32,7 @@
         "clarity-icons": "^0.10.27",
         "clarity-ui": "^0.10.27",
         "core-js": "^2.4.1",
-        "harbor-ui": "0.7.18-dev.8",
+        "harbor-ui": "0.7.19-dev.3",
         "intl": "^1.2.5",
         "mutationobserver-shim": "^0.3.2",
         "ngx-cookie": "^1.0.0",


### PR DESCRIPTION
Because new version of rxjs you need import each function manually, update code to avoid related errors.
Issues #4923 #4904 are caused by this problem.