### PR TITLE
chown only to the folder to store the config.json

### DIFF
--- a/make/photon/adminserver/start.sh
+++ b/make/photon/adminserver/start.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-if [ -d /etc/adminserver ]; then
-    chown -R 10000:10000 /etc/adminserver
+
+#In the case when the config store is set to filesystem, the directory has to be writable.
+if [ -d /etc/adminserver/config ]; then
+    chown -R 10000:10000 /etc/adminserver/config
 fi
 sudo -E -u \#10000 "/harbor/harbor_adminserver"


### PR DESCRIPTION
Narrow down the scope of `chown` in adminserver because the
/etc/adminserver/config/ is the location to store the config.json file.
And /etc/adminserver/key should be readonly.