### PR TITLE
Add label filter in replication policy API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2959,9 +2959,14 @@ definitions:
         description: >-
           The replication policy filter kind. The valid values are project,
           repository and tag.
+      value:
+        type: 
+          - string
+          - integer
+        description: The value of replication policy filter. When creating repository and tag filter, filling it with the pattern as string. When creating label filter, filling it with label ID as integer.
       pattern:
         type: string
-        description: The replication policy filter pattern.
+        description: Depraceted, use value instead. The replication policy filter pattern.
       metadata:
         type: object
         description: This map object is the replication policy filter metadata.
@@ -3541,7 +3546,7 @@ definitions:
         type: string
         description: The color of label.
       scope:
-        type: integer
+        type: string
         description: The scope of label, g for global labels and p for project labels.
       project_id:
         type: integer

--- a/src/replication/models/filter_test.go
+++ b/src/replication/models/filter_test.go
@@ -35,6 +35,29 @@ func TestValid(t *testing.T) {
 			Kind:    replication.FilterItemKindRepository,
 			Pattern: "*",
 		}: false,
+		&Filter{
+			Kind:  replication.FilterItemKindRepository,
+			Value: "*",
+		}: false,
+		&Filter{
+			Kind: replication.FilterItemKindLabel,
+		}: true,
+		&Filter{
+			Kind:  replication.FilterItemKindLabel,
+			Value: "",
+		}: true,
+		&Filter{
+			Kind:  replication.FilterItemKindLabel,
+			Value: 1.2,
+		}: true,
+		&Filter{
+			Kind:  replication.FilterItemKindLabel,
+			Value: -1,
+		}: true,
+		&Filter{
+			Kind:  replication.FilterItemKindLabel,
+			Value: 1,
+		}: true,
 	}
 
 	for filter, hasError := range cases {

--- a/src/replication/policy/manager.go
+++ b/src/replication/policy/manager.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/vmware/harbor/src/common/dao"
 	persist_models "github.com/vmware/harbor/src/common/models"
+	"github.com/vmware/harbor/src/replication"
 	"github.com/vmware/harbor/src/replication/models"
 	"github.com/vmware/harbor/src/ui/config"
 )
@@ -109,6 +110,11 @@ func convertFromPersistModel(policy *persist_models.RepPolicy) (models.Replicati
 		for i := range filters {
 			if filters[i].Value == nil && len(filters[i].Pattern) > 0 {
 				filters[i].Value = filters[i].Pattern
+			}
+			// convert the type of Value to int64 as the default type of
+			// json Unmarshal for number is float64
+			if filters[i].Kind == replication.FilterItemKindLabel {
+				filters[i].Value = int64(filters[i].Value.(float64))
 			}
 		}
 		ply.Filters = filters

--- a/src/ui/api/models/replication_policy.go
+++ b/src/ui/api/models/replication_policy.go
@@ -56,11 +56,13 @@ func (r *ReplicationPolicy) Valid(v *validation.Validation) {
 		v.SetError("targets", "can not be empty")
 	}
 
-	for _, filter := range r.Filters {
-		filter.Valid(v)
+	for i := range r.Filters {
+		r.Filters[i].Valid(v)
 	}
 
-	if r.Trigger != nil {
+	if r.Trigger == nil {
+		v.SetError("trigger", "can not be empty")
+	} else {
 		r.Trigger.Valid(v)
 	}
 }


### PR DESCRIPTION
The label filter can be used to filter images when do the replication, this commit provides the filter in replication policy