### PR TITLE
Update swagger doc

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3557,6 +3557,10 @@ definitions:
       update_time:
         type: string
         description: The update time of label.
+      inactive:
+        type: boolean
+        description: >-
+          The property is only returned in the label filter of response when getting replication polices. If it's true, the label referenced by the policy is already removed.
   ProjectMemberEntity:
     type: object
     properties:


### PR DESCRIPTION
Add inactive property for label object. The property is used to show the status of label in replication label filter.