### PR TITLE
Fix #4742: fuzzy match label name

### DIFF
--- a/src/common/dao/label.go
+++ b/src/common/dao/label.go
@@ -69,7 +69,11 @@ func ListLabels(query *models.LabelQuery) ([]*models.Label, error) {
 func getLabelQuerySetter(query *models.LabelQuery) orm.QuerySeter {
 	qs := GetOrmer().QueryTable(&models.Label{})
 	if len(query.Name) > 0 {
-		qs = qs.Filter("Name", query.Name)
+		if query.FuzzyMatchName {
+			qs = qs.Filter("Name__icontains", query.Name)
+		} else {
+			qs = qs.Filter("Name", query.Name)
+		}
 	}
 	if len(query.Level) > 0 {
 		qs = qs.Filter("Level", query.Level)

--- a/src/common/dao/label_test.go
+++ b/src/common/dao/label_test.go
@@ -72,7 +72,7 @@ func TestMethodsOfLabel(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, int64(1), total)
 
-	// list
+	// list: exact match
 	labels, err := ListLabels(&models.LabelQuery{
 		Scope:     common.LabelScopeProject,
 		ProjectID: 1,
@@ -81,11 +81,21 @@ func TestMethodsOfLabel(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(labels))
 
-	// list
+	// list: fuzzy match
+	labels, err = ListLabels(&models.LabelQuery{
+		Scope:          common.LabelScopeProject,
+		ProjectID:      1,
+		Name:           label.Name[:1],
+		FuzzyMatchName: true,
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 1, len(labels))
+
+	// list: not exist
 	labels, err = ListLabels(&models.LabelQuery{
 		Scope:     common.LabelScopeProject,
 		ProjectID: 1,
-		Name:      "not_exist_label",
+		Name:      label.Name[:1],
 	})
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(labels))

--- a/src/common/models/label.go
+++ b/src/common/models/label.go
@@ -42,10 +42,11 @@ func (l *Label) TableName() string {
 
 // LabelQuery : query parameters for labels
 type LabelQuery struct {
-	Name      string
-	Level     string
-	Scope     string
-	ProjectID int64
+	Name           string
+	FuzzyMatchName bool // the property is used to determine the query for lable name is fuzzy matching or exaxt matching
+	Level          string
+	Scope          string
+	ProjectID      int64
 	Pagination
 }
 

--- a/src/ui/api/label.go
+++ b/src/ui/api/label.go
@@ -162,8 +162,9 @@ func (l *LabelAPI) Get() {
 // List labels according to the query strings
 func (l *LabelAPI) List() {
 	query := &models.LabelQuery{
-		Name:  l.GetString("name"),
-		Level: common.LabelLevelUser,
+		Name:           l.GetString("name"),
+		FuzzyMatchName: true,
+		Level:          common.LabelLevelUser,
 	}
 
 	scope := l.GetString("scope")

--- a/src/ui/api/label_test.go
+++ b/src/ui/api/label_test.go
@@ -243,7 +243,7 @@ func TestLabelAPIList(t *testing.T) {
 		}{
 			Scope:     "p",
 			ProjectID: 1,
-			Name:      "test",
+			Name:      "tes",
 		},
 	}, &labels)
 	require.Nil(t, err)


### PR DESCRIPTION
This commit provides the support of fuzzy matching for label name when listing labels