### PR TITLE
Soft delete label

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3557,10 +3557,9 @@ definitions:
       update_time:
         type: string
         description: The update time of label.
-      inactive:
+      deleted:
         type: boolean
-        description: >-
-          The property is only returned in the label filter of response when getting replication polices. If it's true, the label referenced by the policy is already removed.
+        description: The label is deleted or not.
   ProjectMemberEntity:
     type: object
     properties:

--- a/make/photon/db/registry.sql
+++ b/make/photon/db/registry.sql
@@ -308,6 +308,7 @@ create table harbor_label (
  project_id int,
  creation_time timestamp default 'now'::timestamp,
  update_time timestamp default 'now'::timestamp,
+ deleted boolean DEFAULT false NOT NULL,
  PRIMARY KEY(id),
  CONSTRAINT unique_label UNIQUE (name,scope, project_id)
  );

--- a/src/common/dao/label.go
+++ b/src/common/dao/label.go
@@ -15,6 +15,7 @@
 package dao
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/astaxie/beego/orm"
@@ -80,6 +81,7 @@ func getLabelQuerySetter(query *models.LabelQuery) orm.QuerySeter {
 	if query.ProjectID != 0 {
 		qs = qs.Filter("ProjectID", query.ProjectID)
 	}
+	qs = qs.Filter("Deleted", false)
 	return qs
 }
 
@@ -92,8 +94,13 @@ func UpdateLabel(label *models.Label) error {
 
 // DeleteLabel ...
 func DeleteLabel(id int64) error {
-	_, err := GetOrmer().Delete(&models.Label{
-		ID: id,
-	})
+	label, err := GetLabel(id)
+	if err != nil {
+		return err
+	}
+	label.Name = fmt.Sprintf("%s#%d", label.Name, label.ID)
+	label.UpdateTime = time.Now()
+	label.Deleted = true
+	_, err = GetOrmer().Update(label, "Name", "UpdateTime", "Deleted")
 	return err
 }

--- a/src/common/dao/label_test.go
+++ b/src/common/dao/label_test.go
@@ -106,5 +106,5 @@ func TestMethodsOfLabel(t *testing.T) {
 
 	l, err = GetLabel(id)
 	require.Nil(t, err)
-	assert.Nil(t, l)
+	assert.True(t, l.Deleted)
 }

--- a/src/common/models/label.go
+++ b/src/common/models/label.go
@@ -33,6 +33,7 @@ type Label struct {
 	ProjectID    int64     `orm:"column(project_id)" json:"project_id"`
 	CreationTime time.Time `orm:"column(creation_time)" json:"creation_time"`
 	UpdateTime   time.Time `orm:"column(update_time)" json:"update_time"`
+	Deleted      bool      `orm:"column(deleted)" json:"deleted"`
 }
 
 // TableName ...

--- a/src/ui/api/label.go
+++ b/src/ui/api/label.go
@@ -57,7 +57,7 @@ func (l *LabelAPI) Prepare() {
 			return
 		}
 
-		if label == nil {
+		if label == nil || label.Deleted {
 			l.HandleNotFound(fmt.Sprintf("label %d not found", id))
 			return
 		}
@@ -139,7 +139,7 @@ func (l *LabelAPI) Get() {
 		return
 	}
 
-	if label == nil {
+	if label == nil || label.Deleted {
 		l.HandleNotFound(fmt.Sprintf("label %d not found", id))
 		return
 	}

--- a/src/ui/api/replication_policy_test.go
+++ b/src/ui/api/replication_policy_test.go
@@ -359,9 +359,9 @@ func TestRepPolicyAPIGet(t *testing.T) {
 			label, ok := filter.Value.(map[string]interface{})
 			if assert.True(t, ok) {
 				id := int64(label["id"].(float64))
-				inactive := label["inactive"].(bool)
+				deleted := label["deleted"].(bool)
 				assert.Equal(t, labelID2, id)
-				assert.True(t, inactive)
+				assert.True(t, deleted)
 			}
 		}
 	}

--- a/tools/migration/db/changelog.md
+++ b/tools/migration/db/changelog.md
@@ -75,3 +75,7 @@ Changelog for harbor database schema
   - add `job_uuid` column to `replication_job` and `img_scan_job`
   - add index `poid_status` in table replication_job
   - add index `idx_status`, `idx_status`, `idx_digest`, `idx_repository_tag` in table img_scan_job
+
+## 1.6.0
+
+  - add `deleted` column to table `harbor_label` 


### PR DESCRIPTION
Modify the deletion of label to soft deletion, in this way the names of deleted labels referenced by replication rules can be shown to users