### PR TITLE
Change owner of the file secretkey in prepare.

### DIFF
--- a/make/prepare
+++ b/make/prepare
@@ -144,6 +144,7 @@ def _get_secret(folder, filename, length=16):
         with open(key_file, 'r') as f:
             key = f.read()
             print("loaded secret from file: %s" % key_file)
+        mark_file(key_file)
         return key
     if not os.path.isdir(folder):
         os.makedirs(folder)


### PR DESCRIPTION
The secretkey file will be loaded by adminserver which is run by non-root
user (uid:10000) previously the entrypoint script will run `chown` to a
lot files, and there's a breakage in upgrade when we skip running
`chown` inside container.
This commit will fix the issue during upgrade by changing the owner of
the secretkey file.