### PR TITLE
Add clair data migration in DB migrator

### DIFF
--- a/tools/migration/db/run.sh
+++ b/tools/migration/db/run.sh
@@ -23,6 +23,7 @@ set -e
 ISMYSQL=false
 ISPGSQL=false
 ISNOTARY=false
+ISCLAIR=false
 
 cur_version=""
 PGSQL_USR="postgres" 
@@ -45,6 +46,10 @@ function init {
         ISPGSQL=true
     fi
 
+    if [ -d "/clair-db" ]; then
+        ISCLAIR=true
+    fi
+
     if [ $ISMYSQL == false ] && [ $ISPGSQL == false ]; then
         echo "No database has been mounted for the migration. Use '-v' to set it in 'docker run'."
         exit 1
@@ -65,7 +70,11 @@ function init {
     fi
 
     if [ $ISPGSQL == true ]; then
-        launch_pgsql $PGSQL_USR
+        if [ $ISCLAIR == true ]; then
+            launch_pgsql $PGSQL_USR "/clair-db"
+        else
+            launch_pgsql $PGSQL_USR
+        fi
     fi
 }
 
@@ -130,8 +139,10 @@ function validate {
 function upgrade {
     if [ $ISNOTARY == true ];then
         up_notary $PGSQL_USR
+    elif [ $ISCLAIR == true ];then
+        up_clair $PGSQL_USR
     else
-        up_harbor $1              
+        up_harbor $1          
     fi   
 }
 

--- a/tools/migration/db/util/mysql_pgsql_1_5_0.sh
+++ b/tools/migration/db/util/mysql_pgsql_1_5_0.sh
@@ -80,3 +80,14 @@ EOF
         stop_pgsql $1 
     fi
 }
+
+function up_clair {
+    # clair DB info: user: 'postgres' database: 'postgres'
+    pg_dump -U postgres postgres > /harbor-migration/db/schema/clair.pgsql
+    stop_pgsql postgres "/clair-db"
+
+    # it's harbor DB on pgsql.
+    launch_pgsql $1
+    psql -U $1 -f /harbor-migration/db/schema/clair.pgsql
+    stop_pgsql $1
+}


### PR DESCRIPTION
this commit to fix issue https://github.com/vmware/harbor/issues/5097, add the clair data migration.

[Usage]:
docker run -it -e DB_USR=root -e DB_PWD=${pwd} -v /data/database/:/var/lib/postgresql/data -v /data/clair-db/:/clair-db vmware/harbor-migrator:dev --db up

[Limitation]
For clair migration, there is a necessary precondition that you should not launch harbor before doing it, otherwise the migrator will give a waring message and stop the process.
