### PR TITLE
If group already exist return 409 when adding a LDAP user group

### DIFF
--- a/src/ui/api/usergroup.go
+++ b/src/ui/api/usergroup.go
@@ -101,6 +101,7 @@ func (uga *UserGroupAPI) Post() {
 	}
 	if len(result) > 0 {
 		uga.HandleConflict("Error occurred in add user group, duplicate user group exist.")
+		return
 	}
 	// User can not add ldap group when the ldap server is offline
 	ldapGroup, err := auth.SearchGroup(userGroup.LdapGroupDN)


### PR DESCRIPTION
Not to create the LDAP user group again or update the user group name.