### PR TITLE
Add externalPort in values.yaml

### DIFF
--- a/contrib/helm/harbor/templates/_helpers.tpl
+++ b/contrib/helm/harbor/templates/_helpers.tpl
@@ -30,6 +30,14 @@ release: {{ .Release.Name }}
 app: "{{ template "harbor.name" . }}"
 {{- end -}}
 
+{{- define "harbor.externalURL" -}}
+{{- if .Values.externalPort -}}
+{{- printf "%s:%s" .Values.externalDomain (toString .Values.externalPort) -}}
+{{- else -}}
+{{- .Values.externalDomain -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Use *.domain.com as the Common Name in the certificate,
 so it can match Harbor service FQDN and Notary service FQDN.

--- a/contrib/helm/harbor/templates/notary/notary-cm.yaml
+++ b/contrib/helm/harbor/templates/notary/notary-cm.yaml
@@ -56,7 +56,7 @@ data:
       "auth": {
           "type": "token",
           "options": {
-              "realm": "https://{{ .Values.externalDomain }}/service/token",
+              "realm": "https://{{ template "harbor.externalURL" . }}/service/token",
               "service": "harbor-notary",
               "issuer": "harbor-token-issuer",
               "rootcertbundle": "/root.crt"

--- a/contrib/helm/harbor/templates/registry/registry-cm.yaml
+++ b/contrib/helm/harbor/templates/registry/registry-cm.yaml
@@ -38,7 +38,7 @@ data:
     auth:
       token:
         issuer: harbor-token-issuer
-        realm: "https://{{ .Values.externalDomain }}/service/token"
+        realm: "https://{{ template "harbor.externalURL" . }}/service/token"
         rootcertbundle: /etc/registry/root.crt
         service: harbor-registry
 

--- a/contrib/helm/harbor/templates/registry/registry-ss.yaml
+++ b/contrib/helm/harbor/templates/registry/registry-ss.yaml
@@ -35,7 +35,7 @@ spec:
         - containerPort: 5000
         - containerPort: 5001
         volumeMounts:
-{{- if not .Values.registry.objectStorage }}
+{{- if and (not .Values.registry.objectStorage) .Values.persistence.enabled }}
         - name: registry-data
           mountPath: /var/lib/registry
 {{- end }}

--- a/contrib/helm/harbor/values.yaml
+++ b/contrib/helm/harbor/values.yaml
@@ -33,6 +33,9 @@ harborImageTag: &harbor_image_tag v1.5.0-chart-patch
 
 # The FQDN for Harbor service.
 externalDomain: harbor.my.domain
+# externalPort is the Port for Harbor service, leave empty if the service is to be bound to
+# port 80/443
+externalPort: 32700
 # If set to true, you don't need to set tlsCrt/tlsKey/caCrt, but must add
 # Harbor FQDN as insecure-registries for your docker client.
 insecureRegistry: false


### PR DESCRIPTION
Provide more flexibility for ingress controller setting.  When the
ingress controller is not exposing 80/443 port, user can set `externalPort` to expose the endpoint of Harbor.