### PR TITLE
Parse the error got from jobservice, fix #5047

### DIFF
--- a/src/ui/api/replication_job.go
+++ b/src/ui/api/replication_job.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/vmware/harbor/src/common/dao"
+	common_http "github.com/vmware/harbor/src/common/http"
 	common_job "github.com/vmware/harbor/src/common/job"
 	"github.com/vmware/harbor/src/common/models"
 	"github.com/vmware/harbor/src/common/utils/log"
@@ -195,6 +196,12 @@ func (ra *RepJobAPI) GetLog() {
 
 	logBytes, err := utils.GetJobServiceClient().GetJobLog(job.UUID)
 	if err != nil {
+		if httpErr, ok := err.(*common_http.Error); ok {
+			ra.RenderError(httpErr.Code, "")
+			log.Errorf(fmt.Sprintf("failed to get log of job %d: %d %s",
+				ra.jobID, httpErr.Code, httpErr.Message))
+			return
+		}
 		ra.HandleInternalServerError(fmt.Sprintf("failed to get log of job %s: %v",
 			job.UUID, err))
 		return

--- a/src/ui/api/scan_job.go
+++ b/src/ui/api/scan_job.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"github.com/vmware/harbor/src/common/dao"
+	common_http "github.com/vmware/harbor/src/common/http"
 	"github.com/vmware/harbor/src/common/utils/log"
 	"github.com/vmware/harbor/src/ui/utils"
 
@@ -65,6 +66,12 @@ func (sj *ScanJobAPI) Prepare() {
 func (sj *ScanJobAPI) GetLog() {
 	logBytes, err := utils.GetJobServiceClient().GetJobLog(sj.jobUUID)
 	if err != nil {
+		if httpErr, ok := err.(*common_http.Error); ok {
+			sj.RenderError(httpErr.Code, "")
+			log.Errorf(fmt.Sprintf("failed to get log of job %d: %d %s",
+				sj.jobID, httpErr.Code, httpErr.Message))
+			return
+		}
 		sj.HandleInternalServerError(fmt.Sprintf("Failed to get job logs, uuid: %s, error: %v", sj.jobUUID, err))
 		return
 	}


### PR DESCRIPTION
Parse the error got from jobservice, and return the corresponding HTTP code if it's a HTTP error to caller