### PR TITLE
Fix bug for Harbor UI not updating status of Registry

### DIFF
--- a/contrib/helm/harbor/templates/registry/registry-cm.yaml
+++ b/contrib/helm/harbor/templates/registry/registry-cm.yaml
@@ -41,7 +41,6 @@ data:
         realm: "https://{{ template "harbor.externalURL" . }}/service/token"
         rootcertbundle: /etc/registry/root.crt
         service: harbor-registry
-
     notifications:
       endpoints:
         - name: harbor


### PR DESCRIPTION
Because of newline, notification endpoint configuration is ignored from the config.yml that is mounted into the registry pod. This causes Harbor UI not able to update what happened on the registry and break the role base access control provide by Harbor.