### PR TITLE
Helm: Options to disable ingress objects

### DIFF
--- a/contrib/helm/harbor/README.md
+++ b/contrib/helm/harbor/README.md
@@ -211,6 +211,8 @@ The following tables lists the configurable parameters of the Harbor chart and t
 | `notary.nodeSelector` | Node labels for pod assignment | `{}` |
 | `notary.tolerations` | Tolerations for pod assignment | `[]` |
 | `notary.affinity` | Node/Pod affinities | `{}` |
+| **Ingress** |
+| `ingress.enabled` | Enable ingress objects. | `true` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/contrib/helm/harbor/templates/ingress/ingress.yaml
+++ b/contrib/helm/harbor/templates/ingress/ingress.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.ingress.enabled  }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -56,3 +57,5 @@ spec:
           serviceName: {{ template "harbor.fullname" . }}-ui
           servicePort: 80
 
+
+{{ end }}

--- a/contrib/helm/harbor/values.yaml
+++ b/contrib/helm/harbor/values.yaml
@@ -51,6 +51,7 @@ secretKey: not-a-secure-key
 # These annotations allow the registry to work behind the nginx
 # ingress controller.
 ingress:
+  enabled: true
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     ingress.kubernetes.io/proxy-body-size: "0"


### PR DESCRIPTION
If you are on other kubernetes distros like Openshift, you shouldn't use Ingress.