### PR TITLE
Enable CA cert download on Chart deployment

### DIFF
--- a/contrib/helm/harbor/templates/ui/ui-dpl.yaml
+++ b/contrib/helm/harbor/templates/ui/ui-dpl.yaml
@@ -50,8 +50,11 @@ spec:
         - name: ui-secrets-private-key
           mountPath: /etc/ui/private_key.pem
           subPath: private_key.pem
+        {{- if not .Values.insecureRegistry }}
         - name: ca-download
-          mountPath: /etc/ui/ca
+          mountPath: /etc/ui/ca/ca.crt
+          subPath: ca.crt
+        {{- end }}
         - name: psc
           mountPath: /etc/ui/token
       volumes:
@@ -70,8 +73,14 @@ spec:
           items:
             - key: private_key.pem
               path: private_key.pem
+      {{- if not .Values.insecureRegistry }}
       - name: ca-download
-        emptyDir: {}
+        secret:
+          secretName: "{{ template "harbor.fullname" . }}-ingress"
+          items:
+            - key: ca.crt
+              path: ca.crt
+      {{- end }}
       - name: psc
         emptyDir: {}
     {{- with .Values.ui.nodeSelector }}


### PR DESCRIPTION
This commit fixes #5138.  A volume references the secret will be mounted
to the UI pod, so the user can download the CA cert from UI.