### PR TITLE
Helm: Do not mount secret if ingress is disabled

### DIFF
--- a/contrib/helm/harbor/templates/ui/ui-dpl.yaml
+++ b/contrib/helm/harbor/templates/ui/ui-dpl.yaml
@@ -50,7 +50,7 @@ spec:
         - name: ui-secrets-private-key
           mountPath: /etc/ui/private_key.pem
           subPath: private_key.pem
-        {{- if not .Values.insecureRegistry }}
+        {{- if and (not .Values.insecureRegistry) .Values.ingress.enabled }}
         - name: ca-download
           mountPath: /etc/ui/ca/ca.crt
           subPath: ca.crt
@@ -73,7 +73,7 @@ spec:
           items:
             - key: private_key.pem
               path: private_key.pem
-      {{- if not .Values.insecureRegistry }}
+      {{- if and (not .Values.insecureRegistry) .Values.ingress.enabled }}
       - name: ca-download
         secret:
           secretName: "{{ template "harbor.fullname" . }}-ingress"


### PR DESCRIPTION
Its an follow up form: https://github.com/vmware/harbor/pull/5180

Due a rebase https://github.com/vmware/harbor/pull/5185 was new that I didn't see it instantly.