### PR TITLE
Add rewrite-target annotation to ingress rule

### DIFF
--- a/contrib/helm/harbor/templates/ingress/ingress.yaml
+++ b/contrib/helm/harbor/templates/ingress/ingress.yaml
@@ -41,6 +41,7 @@ metadata:
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
     nginx.ingress.kubernetes.io/rewrite-target: /registryproxy/v2
+    ingress.kubernetes.io/rewrite-target: /registryproxy/v2
 spec:
 {{ if not .Values.insecureRegistry }}
   tls:


### PR DESCRIPTION
The annotation prefix changes in a specific version of nginx controller, add the two kinds of annotation for rewrite-target to the rule to make it works.