### PR TITLE
Restrict the CPU usage of Clair

### DIFF
--- a/make/docker-compose.clair.tpl
+++ b/make/docker-compose.clair.tpl
@@ -22,7 +22,7 @@ services:
     container_name: clair
     image: vmware/clair-photon:__clair_version__
     restart: always
-    cpu_quota: 150000
+    cpu_quota: 50000
     depends_on:
       - postgresql
     volumes:


### PR DESCRIPTION
Fixes #5072

Due to an issue in bzr, Clair container may consume a lot of CPU
resource while updating the vuln data.  This commit mitigates the impact
by setting the cpu_quota of clair container. (default value of
cpu_period is 100000 in v2 docker-compose template)