### PR TITLE
Fix CI pipeline bug on packaging offline installer

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -181,6 +181,7 @@ fi
 #                                     latest.build
 #                                     harbor-offline-installer-latest.tgz
 #
+set -e
 if [ $upload_build == true ] && [ $rc -eq 0 ]; then
     cp $harbor_build_bundle harbor-offline-installer-latest.tgz
     uploader $harbor_build_bundle $harbor_target_bucket
@@ -207,5 +208,3 @@ fi
 if [ -f "$keyfile" ]; then
   rm -f $keyfile
 fi
-
-exit $rc

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -21,7 +21,6 @@ Library  Process
 Library  SSHLibrary  1 minute
 Library  DateTime
 Library  Selenium2Library  10  10
-Library  JSONLibrary
 Resource  Nimbus-Util.robot
 Resource  Vsphere-Util.robot
 Resource  VCH-Util.robot
@@ -36,6 +35,7 @@ Resource  Harbor-Pages/Project-Members.robot
 Resource  Harbor-Pages/Project-Members_Elements.robot
 Resource  Harbor-Pages/Project-Repository.robot
 Resource  Harbor-Pages/Project-Repository_Elements.robot
+Resource  Harbor-Pages/Project-Config.robot
 Resource  Harbor-Pages/Replication.robot
 Resource  Harbor-Pages/Replication_Elements.robot
 Resource  Harbor-Pages/UserProfile.robot
@@ -51,6 +51,4 @@ Resource  Admiral-Util.robot
 Resource  OVA-Util.robot
 Resource  Cert-Util.robot
 Resource  SeleniumUtil.robot
-Resource  Harbor-Pages/Project-Config.robot
 Resource  Nightly-Util.robot
-Resource  Harbor-Pages/Verify.robot


### PR DESCRIPTION
This commit is to fix the bug introduced by PR https://github.com/vmware/harbor/pull/5207/, which adds the json library but doesn't install it in the E2E engine. The bug will cause an runtime error when to exsecute robot framework. Disable it temporary as the upgrade script havn't added into the nightly test. 

And also make the CI pipeline script to throw error on packing/uploading offline installer, otherwise the latest installer will not be updated by the lastest code change.