### PR TITLE
Workaround the Clair issue in ubuntu updater

### DIFF
--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -114,7 +114,7 @@ _build_clair:
 	@if [ "$(CLAIRFLAG)" = "true" ] ; then \
 		if [ "$(BUILDBIN)" != "true" ] ; then \
 			rm -rf $(DOCKERFILEPATH_CLAIR)/binary && mkdir -p $(DOCKERFILEPATH_CLAIR)/binary && \
-			$(call _get_binary, https://storage.googleapis.com/harbor-builds/bin/clair, $(DOCKERFILEPATH_CLAIR)/binary/clair); \
+			$(call _get_binary, https://storage.googleapis.com/harbor-builds/bin/clair-fix-ubuntu-url, $(DOCKERFILEPATH_CLAIR)/binary/clair); \
 		else \
 			cd $(DOCKERFILEPATH_CLAIR) && $(DOCKERFILEPATH_CLAIR)/builder $(CLAIRVERSION); \
 		fi ; \


### PR DESCRIPTION
This commit is a temp fix to workaround coreos/clair#562
Recompiled the code at the tip of release-2.0 branch of clair and
updated Makefile.
Once clair provides a new release, we'll need to make update in
Makefiles and Dockerfiles again to consume it.