### PR TITLE
Change empty_subj to fix #2920 openssl issue

### DIFF
--- a/make/prepare
+++ b/make/prepare
@@ -504,7 +504,7 @@ def openssl_installed():
 
 if customize_crt == 'on' and openssl_installed():
     shell_stat = subprocess.check_call(["which", "openssl"], stdout=FNULL, stderr=subprocess.STDOUT)
-    empty_subj = "/C=/ST=/L=/O=/CN=/"
+    empty_subj = "/"
     private_key_pem = os.path.join(config_dir, "ui", "private_key.pem")
     root_crt = os.path.join(config_dir, "registry", "root.crt")
     create_root_cert(empty_subj, key_path=private_key_pem, cert_path=root_crt)


### PR DESCRIPTION
This is a simple replacement to fix the #2920 `install.sh Fail to generate key file` `openssl` issue on recent linux distributions (Debian 9). The solution was first mentioned by @teknologist but apparently nobody did a PR to avoid having to apply manually the workaround.