### PR TITLE
Update docker registry cache from inmemory to redis.

### DIFF
--- a/make/common/templates/registry/config.yml
+++ b/make/common/templates/registry/config.yml
@@ -5,13 +5,16 @@ log:
     service: registry
 storage:
   cache:
-    layerinfo: inmemory
+    layerinfo: redis
   $storage_provider_info
   maintenance:
     uploadpurging:
       enabled: false
   delete:
     enabled: true
+redis:
+  addr: $redis_url
+  db: 1
 http:
   addr: :5000
   secret: placeholder

--- a/make/common/templates/registry/config_ha.yml
+++ b/make/common/templates/registry/config_ha.yml
@@ -14,15 +14,7 @@ storage:
     enabled: true
 redis:
   addr: $redis_url
-  db: 0
-  dialtimeout: 10ms
-  readtimeout: 10ms
-  writetimeout: 10ms
-  pool:
-    maxidle: 16
-    maxactive: 64
-    idletimeout: 300s
-
+  db: 1
 http:
   addr: :5000
   secret: placeholder

--- a/make/prepare
+++ b/make/prepare
@@ -415,7 +415,8 @@ render(os.path.join(templates_dir, "ui", "env"),
         adminserver_url = adminserver_url
         )
 
-registry_config_file = "config_ha.yml" if args.ha_mode else "config.yml"
+registry_config_file_ha = "config_ha.yml"
+registry_config_file = "config.yml"
 if storage_provider_name == "filesystem":
     if not storage_provider_config:
         storage_provider_config = "rootdirectory: /storage"
@@ -426,6 +427,13 @@ storage_provider_conf_list = [storage_provider_name + ':']
 for c in storage_provider_config.split(","):
     storage_provider_conf_list.append(c.strip())
 storage_provider_info = ('\n' + ' ' * 4).join(storage_provider_conf_list)
+render(os.path.join(templates_dir, "registry", registry_config_file_ha),
+    registry_conf,
+    storage_provider_info=storage_provider_info,
+    public_url=public_url,
+    ui_url=ui_url,
+    redis_url=redis_url)
+
 render(os.path.join(templates_dir, "registry", registry_config_file),
     registry_conf,
     storage_provider_info=storage_provider_info,


### PR DESCRIPTION
It gives Harbor the capability to controll the cache of docker
registry, and the workaround for cache invalidation bug caused
by garbage collection, that is clean cache in GC job.

For more details, see Harbor issue #5078.