### PR TITLE
Let adminserver initialise the DB schema.

### DIFF
--- a/make/photon/adminserver/Dockerfile
+++ b/make/photon/adminserver/Dockerfile
@@ -7,7 +7,7 @@ RUN tdnf erase vim -y \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -g 10000 -u 10000 harbor \
     && mkdir /harbor/
 COPY ./make/dev/adminserver/harbor_adminserver ./make/photon/adminserver/start.sh /harbor/
-#There is a race condition that both ui and adminserver may initialize schema
+#As UI will be blocked until adminserver is ready, let adminserver do the initialise work for DB
 COPY ./make/migrations /harbor/migrations
 
 HEALTHCHECK CMD curl --fail -s http://127.0.0.1:8080/api/ping || exit 1 

--- a/make/photon/ui/Dockerfile
+++ b/make/photon/ui/Dockerfile
@@ -11,8 +11,6 @@ HEALTHCHECK CMD curl --fail -s http://127.0.0.1:8080/api/ping || exit 1
 COPY ./make/dev/ui/harbor_ui ./src/favicon.ico ./make/photon/ui/start.sh ./UIVERSION /harbor/
 COPY ./src/ui/views /harbor/views
 COPY ./src/ui/static /harbor/static
-#There is a race condition that both ui and adminserver may initialize schema
-COPY ./make/migrations /harbor/migrations
 
 RUN chmod u+x /harbor/start.sh /harbor/harbor_ui
 WORKDIR /harbor/

--- a/src/ui/main.go
+++ b/src/ui/main.go
@@ -92,7 +92,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to get database configuration: %v", err)
 	}
-	if err := dao.InitDatabase(database, true); err != nil {
+	if err := dao.InitDatabase(database); err != nil {
 		log.Fatalf("failed to initialize database: %v", err)
 	}
 	if config.WithClair() {
@@ -151,16 +151,16 @@ func main() {
 
 	syncRegistry := os.Getenv("SYNC_REGISTRY")
 	sync, err := strconv.ParseBool(syncRegistry)
-	if err != nil{
+	if err != nil {
 		log.Errorf("Failed to parse SYNC_REGISTRY: %v", err)
 		//if err set it default to false
-		sync = false;
+		sync = false
 	}
-	if sync{
+	if sync {
 		if err := api.SyncRegistry(config.GlobalProjectMgr); err != nil {
 			log.Error(err)
 		}
-	}else {
+	} else {
 		log.Infof("Because SYNC_REGISTRY set false , no need to sync registry \n")
 	}
 


### PR DESCRIPTION
This commit make update to remove the code from ui container to init the
DB schema.  As UI has dependency on admin server, so it's safe to assume
adminserver has to be ready first.  Regardless the setting of the config
store of admin server, it will try to access and intialize the schema of
database.