### PR TITLE
Remove lost+found folder in database volume on initial start

### DIFF
--- a/contrib/helm/harbor/templates/database/database-ss.yaml
+++ b/contrib/helm/harbor/templates/database/database-ss.yaml
@@ -19,6 +19,13 @@ spec:
 {{ include "harbor.labels" . | indent 8 }}
         component: database
     spec:
+      initContainers:
+      - name: "remove-lost-found"
+        image: "busybox:1.25.0"
+        command: ["rm", "-Rf", "/var/lib/postgresql/data/lost+found"]
+        volumeMounts:
+        - name: database-data
+          mountPath: /var/lib/postgresql/data
       containers:
       - name: database
         image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}


### PR DESCRIPTION
Postgres was complaning about a `lost+found` folder in the data folder. This happens because the volume is directly mounted into the directory `/var/lib/postgresql/data`. This pull request will remove the folder if it exists before the container starts.

Another solution could be to create a subfolder and set the `PGDATA` env to this subfolder, but this will break current deployments.