### PR TITLE
Support the configuration of registry storage in helm chart

### DIFF
--- a/contrib/helm/harbor/templates/registry/registry-cm.yaml
+++ b/contrib/helm/harbor/templates/registry/registry-cm.yaml
@@ -12,11 +12,122 @@ data:
       fields:
         service: registry
     storage:
-      {{- if .Values.registry.objectStorage }}
-{{ toYaml .Values.registry.objectStorage | indent 6 }}
-      {{- else }}
+      {{- $storage := .Values.registry.storage }}
+      {{- $type := $storage.type }}
+      {{- if eq $type "filesystem" }}
       filesystem:
-        rootdirectory: /var/lib/registry
+        rootdirectory: {{ $storage.filesystem.rootdirectory }}
+        {{- if $storage.filesystem.maxthreads }}
+        maxthreads: {{ $storage.filesystem.maxthreads }}
+        {{- end }}
+      {{- else if eq $type "azure" }}
+      azure:
+        accountname: {{ $storage.azure.accountname }}
+        container: {{ $storage.azure.container }}
+        {{- if $storage.azure.realm }}
+        realm: {{ $storage.azure.realm }}
+        {{- end }}
+      {{- else if eq $type "gcs" }}
+      gcs:
+        bucket: {{ $storage.gcs.bucket }}
+        {{- if $storage.gcs.rootdirectory }}
+        rootdirectory: {{ $storage.gcs.rootdirectory }}
+        {{- end }}
+        {{- if $storage.gcs.chunksize }}
+        chunksize: {{ $storage.gcs.chunksize }}
+        {{- end }}
+      {{- else if eq $type "s3" }}
+      s3:
+        region: {{ $storage.s3.region }}
+        bucket: {{ $storage.s3.bucket }}
+        {{- if $storage.s3.regionendpoint }}
+        regionendpoint: {{ $storage.s3.regionendpoint }}
+        {{- end }}
+        {{- if $storage.s3.encrypt }}
+        encrypt: {{ $storage.s3.encrypt }}
+        {{- end }}
+        {{- if $storage.s3.secure }}
+        secure: {{ $storage.s3.secure }}
+        {{- end }}
+        {{- if $storage.s3.v4auth }}
+        v4auth: {{ $storage.s3.v4auth }}
+        {{- end }}
+        {{- if $storage.s3.chunksize }}
+        chunksize: {{ $storage.s3.chunksize }}
+        {{- end }}
+        {{- if $storage.s3.rootdirectory }}
+        rootdirectory: {{ $storage.s3.rootdirectory }}
+        {{- end }}
+        {{- if $storage.s3.storageclass }}
+        storageclass: {{ $storage.s3.storageclass }}
+        {{- end }}
+      {{- else if eq $type "swift" }}
+      swift:
+        authurl: {{ $storage.swift.authurl }}
+        username: {{ $storage.swift.username }}
+        container: {{ $storage.swift.container }}
+        {{- if $storage.swift.region }}
+        region: {{ $storage.swift.region }}
+        {{- end }}
+        {{- if $storage.swift.tenant }}
+        tenant: {{ $storage.swift.tenant }}
+        {{- end }}
+        {{- if $storage.swift.tenantid }}
+        tenantid: {{ $storage.swift.tenantid }}
+        {{- end }}
+        {{- if $storage.swift.domain }}
+        domain: {{ $storage.swift.domain }}
+        {{- end }}
+        {{- if $storage.swift.domainid }}
+        domainid: {{ $storage.swift.domainid }}
+        {{- end }}
+        {{- if $storage.swift.trustid }}
+        trustid: {{ $storage.swift.trustid }}
+        {{- end }}
+        {{- if $storage.swift.insecureskipverify }}
+        insecureskipverify: {{ $storage.swift.insecureskipverify }}
+        {{- end }}
+        {{- if $storage.swift.chunksize }}
+        chunksize: {{ $storage.swift.chunksize }}
+        {{- end }}
+        {{- if $storage.swift.prefix }}
+        prefix: {{ $storage.swift.prefix }}
+        {{- end }}
+        {{- if $storage.swift.authversion }}
+        authversion: {{ $storage.swift.authversion }}
+        {{- end }}
+        {{- if $storage.swift.endpointtype }}
+        endpointtype: {{ $storage.swift.endpointtype }}
+        {{- end }}
+        {{- if $storage.swift.tempurlcontainerkey }}
+        tempurlcontainerkey: {{ $storage.swift.tempurlcontainerkey }}
+        {{- end }}
+        {{- if $storage.swift.tempurlmethods }}
+        tempurlmethods: {{ $storage.swift.tempurlmethods }}
+        {{- end }}
+      {{- else if eq $type "oss" }}
+      oss:
+        accesskeyid: {{ $storage.oss.accesskeyid }}
+        region: {{ $storage.oss.region }}
+        bucket: {{ $storage.oss.bucket }}
+        {{- if $storage.oss.endpoint }}
+        endpoint: {{ $storage.oss.endpoint }}
+        {{- end }}
+        {{- if $storage.oss.internal }}
+        internal: {{ $storage.oss.internal }}
+        {{- end }}
+        {{- if $storage.oss.encrypt }}
+        encrypt: {{ $storage.oss.encrypt }}
+        {{- end }}
+        {{- if $storage.oss.secure }}
+        secure: {{ $storage.oss.secure }}
+        {{- end }}
+        {{- if $storage.oss.chunksize }}
+        chunksize: {{ $storage.oss.chunksize }}
+        {{- end }}
+        {{- if $storage.oss.rootdirectory }}
+        rootdirectory: {{ $storage.oss.rootdirectory }}
+        {{- end }}
       {{- end }}
       cache:
         layerinfo: inmemory

--- a/contrib/helm/harbor/templates/registry/registry-secret.yaml
+++ b/contrib/helm/harbor/templates/registry/registry-secret.yaml
@@ -8,3 +8,25 @@ type: Opaque
 data:
   httpSecret: {{ .Values.registry.httpSecret | b64enc | quote }}
   root.crt: {{ .Values.registry.rootCrt | b64enc | quote }}
+  {{- $storage := .Values.registry.storage }}
+  {{- $type := $storage.type }}
+  {{- if eq $type "azure" }}
+  accountkey: {{ $storage.azure.accountkey | b64enc | quote }}
+  {{- else if eq $type "s3" }}
+  {{- if $storage.s3.accesskey }}
+  accesskey: {{ $storage.s3.accesskey | b64enc | quote }}
+  {{- end }}
+  {{- if $storage.s3.secretkey }}
+  secretkey: {{ $storage.s3.secretkey | b64enc | quote }}
+  {{- end }}
+  {{- else if eq $type "swift" }}
+  password: {{ $storage.swift.password }}
+  {{- if $storage.swift.secretkey }}
+  secretkey: {{ $storage.swift.secretkey }}
+  {{- end }}
+  {{- if $storage.swift.accesskey }}
+  accesskey: {{ $storage.swift.accesskey }}
+  {{- end }}
+  {{- else if eq $type "oss" }}
+  accesskeysecret: {{ $storage.oss.accesskeysecret }}
+  {{- end }}

--- a/contrib/helm/harbor/templates/registry/registry-ss.yaml
+++ b/contrib/helm/harbor/templates/registry/registry-ss.yaml
@@ -31,14 +31,64 @@ spec:
               secretKeyRef:
                 name: "{{ template "harbor.fullname" . }}-registry"
                 key: httpSecret
+          {{- $storage := .Values.registry.storage }}
+          {{- $type := $storage.type }}
+          {{- if eq $type "azure" }}
+          - name: REGISTRY_STORAGE_AZURE_ACCOUNTKEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-registry"
+                key: accountkey
+          {{- else if eq $type "s3" }}
+          {{- if $storage.s3.accesskey }}
+          - name: REGISTRY_STORAGE_S3_ACCESSKEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-registry"
+                key: accesskey
+          {{- end }}
+          {{- if $storage.s3.secretkey }}
+          - name: REGISTRY_STORAGE_S3_SECRETKEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-registry"
+                key: secretkey
+          {{- end }}
+          {{- else if eq $type "swift" }}
+          - name: REGISTRY_STORAGE_SWIFT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-registry"
+                key: password
+          {{- if $storage.swift.secretkey }}
+          - name: REGISTRY_STORAGE_SWIFT_SECRETKEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-registry"
+                key: secretkey
+          {{- end }}
+          {{- if $storage.swift.accesskey }}
+          - name: REGISTRY_STORAGE_SWIFT_ACCESSKEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-registry"
+                key: accesskey
+          {{- end }}
+          {{- else if eq $type "oss" }}
+          - name: REGISTRY_STORAGE_OSS_ACCESSKEYSECRET
+            valueFrom:
+              secretKeyRef:
+                name: "{{ template "harbor.fullname" . }}-registry"
+                key: accesskeysecret
+          {{- end }}
         ports:
         - containerPort: 5000
         - containerPort: 5001
         volumeMounts:
-{{- if and (not .Values.registry.objectStorage) .Values.persistence.enabled }}
+        {{- if (.Values.persistence.enabled) and eq .Values.registry.storage.type "filesystem" }}
         - name: registry-data
-          mountPath: /var/lib/registry
-{{- end }}
+          mountPath: {{ .Values.registry.storage.filesystem.rootdirectory }}
+        {{- end }}
         - name: registry-root-certificate
           mountPath: /etc/registry/root.crt
           subPath: root.crt
@@ -64,7 +114,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-  {{- if and (not .Values.registry.objectStorage) .Values.persistence.enabled }}
+  {{- if (.Values.persistence.enabled) and eq .Values.registry.storage.type "filesystem" }}
   volumeClaimTemplates:
   - metadata:
       name: registry-data
@@ -82,4 +132,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.registry.volumes.data.size | quote }}
-  {{- end -}}
+  {{- end }}

--- a/contrib/helm/harbor/values.yaml
+++ b/contrib/helm/harbor/values.yaml
@@ -189,22 +189,68 @@ registry:
     pullPolicy: IfNotPresent
   httpSecret: not-a-secure-secret
   logLevel: info
-# comment out one of the below to use your cloud's object storage.
-#  objectStorage:
-#    gcs:
-#      keyfile: ""
-#      bucket: ""
-#      chunksize: "5242880"
-#    s3:
-#      region: ""
-#      accesskey: ""
-#      secretkey: ""
-#      bucket: ""
-#      encrypt: "true"
-#    azure:
-#      accountname: ""
-#      accountkey: ""
-#      container: ""
+  storage:
+    # specify the type of storage: "filesystem", "azure", "gcs", "s3", "swift", 
+    # "oss" and fill the information needed in the corresponding section
+    type: filesystem
+    filesystem:
+      rootdirectory: /var/lib/registry
+      #maxthreads: 100
+    azure:
+      accountname: accountname
+      accountkey: base64encodedaccountkey
+      container: containername
+      #realm: core.windows.net
+    gcs:
+      bucket: bucketname
+      # TODO: support the keyfile of gcs
+      #keyfile: /path/to/keyfile
+      #rootdirectory: /gcs/object/name/prefix
+      #chunksize: 5242880
+    s3:
+      region: us-west-1
+      bucket: bucketname
+      #accesskey: awsaccesskey
+      #secretkey: awssecretkey
+      #regionendpoint: http://myobjects.local
+      #encrypt: false
+      #keyid: mykeyid
+      #secure: true
+      #v4auth: true
+      #chunksize: 5242880
+      #rootdirectory: /s3/object/name/prefix
+      #storageclass: STANDARD
+    swift:
+      authurl: https://storage.myprovider.com/v3/auth
+      username: username
+      password: password
+      container: containername
+      #region: fr
+      #tenant: tenantname
+      #tenantid: tenantid
+      #domain: domainname
+      #domainid: domainid
+      #trustid: trustid
+      #insecureskipverify: false
+      #chunksize: 5M
+      #prefix:
+      #secretkey: secretkey
+      #accesskey: accesskey
+      #authversion: 3
+      #endpointtype: public
+      #tempurlcontainerkey: false
+      #tempurlmethods:
+    oss:
+      accesskeyid: accesskeyid
+      accesskeysecret: accesskeysecret
+      region: regionname
+      bucket: bucketname
+      #endpoint: endpoint
+      #internal: false
+      #encrypt: false
+      #secure: true
+      #chunksize: 10M
+      #rootdirectory: rootdirectory
   rootCrt: |
     -----BEGIN CERTIFICATE-----
     MIIE0zCCArugAwIBAgIJAIgs3S+hsjhmMA0GCSqGSIb3DQEBCwUAMAAwHhcNMTcx


### PR DESCRIPTION
This commit adds the registry storage configuration to the values.yaml. By this way, users can cusomize the storage they use.