### PR TITLE
Update photon base images

### DIFF
--- a/make/photon/adminserver/Dockerfile
+++ b/make/photon/adminserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 RUN tdnf erase vim -y \
     && tdnf distro-sync -y \

--- a/make/photon/clair/Dockerfile
+++ b/make/photon/clair/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 
 RUN tdnf distro-sync -y \

--- a/make/photon/db/Dockerfile
+++ b/make/photon/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 ENV PGDATA /var/lib/postgresql/data
 

--- a/make/photon/jobservice/Dockerfile
+++ b/make/photon/jobservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 RUN mkdir /harbor/ \
     && tdnf distro-sync -y \

--- a/make/photon/log/Dockerfile
+++ b/make/photon/log/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 RUN tdnf distro-sync -y \
     && tdnf install -y cronie rsyslog logrotate shadow tar gzip sudo net-tools >> /dev/null\

--- a/make/photon/nginx/Dockerfile
+++ b/make/photon/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 RUN tdnf distro-sync -y \
     && tdnf install -y nginx >> /dev/null\

--- a/make/photon/notary/server.Dockerfile
+++ b/make/photon/notary/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 RUN tdnf distro-sync -y \
     && tdnf erase vim -y \

--- a/make/photon/notary/signer.Dockerfile
+++ b/make/photon/notary/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 RUN tdnf distro-sync -y \
     && tdnf erase vim -y \

--- a/make/photon/redis/Dockerfile
+++ b/make/photon/redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 RUN tdnf distro-sync -y \
     && tdnf install -y redis sudo 

--- a/make/photon/registry/Dockerfile
+++ b/make/photon/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 MAINTAINER wangyan@vmware.com
 

--- a/make/photon/registryctl/Dockerfile
+++ b/make/photon/registryctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 MAINTAINER wangyan@vmware.com
 

--- a/make/photon/ui/Dockerfile
+++ b/make/photon/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 RUN tdnf distro-sync -y \
     && tdnf erase vim -y \

--- a/tools/migration/Dockerfile
+++ b/tools/migration/Dockerfile
@@ -1,4 +1,4 @@
-FROM vmware/photon:1.0
+FROM photon:1.0
 
 ENV PGDATA /var/lib/postgresql/data
 


### PR DESCRIPTION
This commit update the base photon image from vmware/photon:1.0 to
photon:1.0, per suggestion by photon team.