### PR TITLE
Fix the multipart form data content missing issue by refill the content again before passing to the backend server

### DIFF
--- a/src/chartserver/chart_operator.go
+++ b/src/chartserver/chart_operator.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	readmeFileName = "README.md"
+	valuesFileName = "values.yaml"
 )
 
 //ChartVersionDetails keeps the detailed data info of the chart version
@@ -72,7 +73,7 @@ func (cho *ChartOperator) GetChartDetails(content []byte) (*ChartVersionDetails,
 		values = parseRawValues([]byte(chartData.Values.GetRaw()))
 		if len(values) > 0 {
 			//Append values.yaml file
-			files["values.yaml"] = chartData.Values.Raw
+			files[valuesFileName] = chartData.Values.Raw
 		}
 	}
 

--- a/src/chartserver/client.go
+++ b/src/chartserver/client.go
@@ -75,6 +75,10 @@ func (cc *ChartClient) GetContent(addr string) ([]byte, error) {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
+		if err := extractError(content); err != nil {
+			return nil, err
+		}
+
 		return nil, fmt.Errorf("failed to retrieve content from '%s' with error: %s", fullURI.Path, content)
 	}
 

--- a/src/chartserver/manipulation_handler.go
+++ b/src/chartserver/manipulation_handler.go
@@ -49,19 +49,19 @@ func (mh *ManipulationHandler) ListCharts(w http.ResponseWriter, req *http.Reque
 
 	content, err := mh.apiClient.GetContent(url)
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 
 	chartList, err := mh.chartOperator.GetChartList(content)
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 
 	jsonData, err := json.Marshal(chartList)
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 
@@ -79,7 +79,7 @@ func (mh *ManipulationHandler) GetChart(w http.ResponseWriter, req *http.Request
 func (mh *ManipulationHandler) GetChartVersion(w http.ResponseWriter, req *http.Request) {
 	chartV, err := mh.getChartVersion(req.URL.String())
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 
@@ -97,20 +97,20 @@ func (mh *ManipulationHandler) GetChartVersion(w http.ResponseWriter, req *http.
 		}
 
 		if len(strings.TrimSpace(namespace)) == 0 {
-			writeInternalError(w, errors.New("failed to extract namespace from the request"))
+			WriteInternalError(w, errors.New("failed to extract namespace from the request"))
 			return
 		}
 
 		content, err := mh.getChartVersionContent(namespace, chartV.URLs[0])
 		if err != nil {
-			writeInternalError(w, err)
+			WriteInternalError(w, err)
 			return
 		}
 
 		//Process bytes and get more details of chart version
 		chartDetails, err = mh.chartOperator.GetChartDetails(content)
 		if err != nil {
-			writeInternalError(w, err)
+			WriteInternalError(w, err)
 			return
 		}
 		chartDetails.Metadata = chartV
@@ -127,7 +127,7 @@ func (mh *ManipulationHandler) GetChartVersion(w http.ResponseWriter, req *http.
 
 	bytes, err := json.Marshal(chartDetails)
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 

--- a/src/chartserver/repo_handler.go
+++ b/src/chartserver/repo_handler.go
@@ -60,14 +60,14 @@ func (rh *RepositoryHandler) GetIndexFile(w http.ResponseWriter, req *http.Reque
 	//Get project manager references
 	projectMgr, err := filter.GetProjectManager(req)
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 
 	//Get all the projects
 	results, err := projectMgr.List(nil)
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 
@@ -179,7 +179,7 @@ LOOP:
 	//All the threads are done
 	//Met an error
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 
@@ -195,7 +195,7 @@ LOOP:
 
 	bytes, err := yaml.Marshal(mergedIndexFile)
 	if err != nil {
-		writeInternalError(w, err)
+		WriteInternalError(w, err)
 		return
 	}
 

--- a/src/chartserver/utils.go
+++ b/src/chartserver/utils.go
@@ -14,8 +14,8 @@ const (
 	contentTypeJSON   = "application/json"
 )
 
-//Write error to http client
-func writeError(w http.ResponseWriter, code int, err error) {
+//WriteError writes error to http client
+func WriteError(w http.ResponseWriter, code int, err error) {
 	errorObj := make(map[string]string)
 	errorObj["error"] = err.Error()
 	errorContent, _ := json.Marshal(errorObj)
@@ -24,9 +24,9 @@ func writeError(w http.ResponseWriter, code int, err error) {
 	w.Write(errorContent)
 }
 
-//StatusCode == 500
-func writeInternalError(w http.ResponseWriter, err error) {
-	writeError(w, http.StatusInternalServerError, err)
+//WriteInternalError writes error with statusCode == 500
+func WriteInternalError(w http.ResponseWriter, err error) {
+	WriteError(w, http.StatusInternalServerError, err)
 }
 
 //Write JSON data to http client
@@ -34,6 +34,26 @@ func writeJSONData(w http.ResponseWriter, data []byte) {
 	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write(data)
+}
+
+//Extract error object '{"error": "****---***"}' from the content if existing
+//nil error will be returned if it does exist
+func extractError(content []byte) error {
+	if len(content) == 0 {
+		return nil
+	}
+
+	errorObj := make(map[string]string)
+	err := json.Unmarshal(content, &errorObj)
+	if err != nil {
+		return nil
+	}
+
+	if errText, ok := errorObj["error"]; ok {
+		return errors.New(errText)
+	}
+
+	return nil
 }
 
 //Parse the redis configuration to the beego cache pattern


### PR DESCRIPTION
**Fix the multipart form data content missing issue by refill the content again before passing to the backend server**

- refill the multipart form data at harbor API layer
- export write error functions from the chartserver package
- refactor the error format to be compatiable with push plugin