### PR TITLE
Fix issue install clair the first time use scan will have undefined e…

### DIFF
--- a/src/ui_ng/lib/src/vulnerability-scanning/result-bar-chart.component.ts
+++ b/src/ui_ng/lib/src/vulnerability-scanning/result-bar-chart.component.ts
@@ -119,7 +119,12 @@ export class ResultBarChartComponent implements OnInit, OnDestroy {
                 this.onSubmitting = false;
 
                 // Forcely change status to queued after successful submitting
-                this.summary.scan_status = VULNERABILITY_SCAN_STATUS.pending;
+                this.summary = {
+                    scan_status: VULNERABILITY_SCAN_STATUS.pending,
+                    severity: null,
+                    components: null,
+                    update_time: null
+                };
 
                 // Forcely refresh view
                 this.forceRefreshView(1000);
@@ -174,7 +179,7 @@ export class ResultBarChartComponent implements OnInit, OnDestroy {
     }
 
     copyValue(newVal: VulnerabilitySummary): void {
-        if (!newVal || !newVal.scan_status) { return; }
+        if (!this.summary || !newVal || !newVal.scan_status) { return; }
         this.summary.scan_status = newVal.scan_status;
         this.summary.job_id = newVal.job_id;
         this.summary.severity = newVal.severity;


### PR DESCRIPTION
Description:
Reproduce Steps:
1 User install Clair
2 User use scan to scan the image
2 There will be a notification pop with undefined error
Root cause:
In result-bar-chart-component.ts  copyValue function
  this.summary.scan_status = newVal.scan_status;
It try to set scan status to summary object.
Somehow, the first time summary is undefined. It will cause this error.

Fix:
1 Do a empty check before assign value to a object.
2 Set a default value to summary.