### PR TITLE
Notification should not hide content according to ux

### DIFF
--- a/src/ui_ng/src/app/global-message/message.component.scss
+++ b/src/ui_ng/src/app/global-message/message.component.scss
@@ -1,9 +1,10 @@
 .global-message-alert {
-    position: absolute;
+    position: relative;
     top: 0;
     left: 0;
     width: 100%;
     z-index: 999;
+    margin-bottom: 20px;
 }
 .alert-item {
     display: inline-block;


### PR DESCRIPTION
Issue description:
Notification will hide some content when it popup.

According to ux requirement, we should make it not extend to the whole widh of UI, and should not hide the content.

Fix:
Modify the position from 'absolute' to 'relative', so that it will not hide the content.