### PR TITLE
Use current time as regsitration time for LDAP and UAA users

### DIFF
--- a/src/ui/auth/ldap/ldap.go
+++ b/src/ui/auth/ldap/ldap.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/vmware/harbor/src/common"
 
@@ -124,8 +125,9 @@ func (l *Auth) OnBoardUser(u *models.User) error {
 			u.Email = u.Username + "@placeholder.com"
 		}
 	}
-	u.Password = "12345678AbC" //Password is not kept in local db
-	u.Comment = "from LDAP."   //Source is from LDAP
+	u.Password = "12345678AbC"        //Password is not kept in local db
+	u.Comment = "from LDAP."          //Source is from LDAP
+	u.CreationTime = time.Now().UTC() // Current time is register time
 
 	return dao.OnBoardUser(u)
 }

--- a/src/ui/auth/uaa/uaa.go
+++ b/src/ui/auth/uaa/uaa.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/vmware/harbor/src/common"
 	"github.com/vmware/harbor/src/common/dao"
@@ -70,6 +71,8 @@ func (u *Auth) OnBoardUser(user *models.User) error {
 	}
 	fillEmailRealName(user)
 	user.Comment = "From UAA"
+	user.CreationTime = time.Now().UTC() // Current time is register time
+
 	return dao.OnBoardUser(user)
 }
 


### PR DESCRIPTION
Previous user registration time always displays "1/1/1". change to first login time.