### PR TITLE
Notification should not hide content according to ux

### DIFF
--- a/src/ui_ng/src/app/global-message/message.component.html
+++ b/src/ui_ng/src/app/global-message/message.component.html
@@ -1,4 +1,4 @@
-<div [class.global-message-alert]="!isAppLevel">
+<div [class.alert-app-level]="!isAppLevel">
     <clr-alert [clrAlertType]="globalMessage.type" [clrAlertAppLevel]="isAppLevel" [(clrAlertClosed)]="!globalMessageOpened" (clrAlertClosedChange)="onClose()">
         <div class="alert-item">
             <span class="alert-text">{{message}}</span>

--- a/src/ui_ng/src/app/global-message/message.component.scss
+++ b/src/ui_ng/src/app/global-message/message.component.scss
@@ -1,16 +1,3 @@
-.global-message-alert {
-    position: relative;
-    top: 0;
-    left: 0;
-    width: 100%;
-    z-index: 999;
-    margin-bottom: 20px;
+.alert-app-level {
+    margin-bottom:20px;
 }
-.alert-item {
-    display: inline-block;
-    text-align: center;
-}
-:host >>> .alert-icon-wrapper{
-    display: inline;
-}
-:host >>> .alert.alert-app-level.alert-warning{padding: 0;}


### PR DESCRIPTION
Issue description:
Notification will hide some content when it popup.

According to ux requirement, we should make it not extend to the whole widh of UI, and should not hide the content.

Fix:
Use clarity alert-app-level style,it will show as ux design,and text in center too.