### PR TITLE
Set the content length to -1 to let the reader read all the uploading…

### DIFF
--- a/src/ui/api/chart_repository.go
+++ b/src/ui/api/chart_repository.go
@@ -406,7 +406,7 @@ func (cra *ChartRepositoryAPI) rewriteFileContent(files []formFile, request *htt
 	}
 
 	request.Header.Set(headerContentType, w.FormDataContentType())
-	request.ContentLength = int64(body.Len())
+	request.ContentLength = -1
 	request.Body = ioutil.NopCloser(&body)
 
 	return nil


### PR DESCRIPTION
**Set the content length to -1 to let the reader read all the uploading contents in the request**

- replace bytes.Buffer.Len() with -1