### PR TITLE
Add registry to default no_proxy hosts for Clair

### DIFF
--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -40,7 +40,7 @@ log_rotate_size = 200M
 #Clair doesn't need to connect to harbor ui container via http proxy.
 http_proxy =
 https_proxy =
-no_proxy = 127.0.0.1,localhost,ui
+no_proxy = 127.0.0.1,localhost,ui,registry
 
 #NOTES: The properties between BEGIN INITIAL PROPERTIES and END INITIAL PROPERTIES
 #only take effect in the first boot, the subsequent changes of these properties 


### PR DESCRIPTION
When proxy is set for Clair, there may be issue when Clair pulls image
from the registryif the `no_proxy` attribute is not updated.  This
commit adds `registry` to the default setting.