### PR TITLE
Enable configuring the interval of clair updaters

### DIFF
--- a/make/common/templates/clair/config.yaml
+++ b/make/common/templates/clair/config.yaml
@@ -16,7 +16,7 @@ clair:
     # Deadline before an API request will respond with a 503
     timeout: 300s
   updater:
-    interval: 12h
+    interval: ${interval}h
 
   notifier:
     attempts: 3

--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -148,19 +148,18 @@ redis_url = redis:6379
 
 #Clair DB host address. Only change it when using an exteral DB.
 clair_db_host = postgresql
-
 #The password of the Clair's postgres database. Only effective when Harbor is deployed with Clair.
 #Please update it before deployment. Subsequent update will cause Clair's API server and Harbor unable to access Clair's database.
 clair_db_password = root123
-
 #Clair DB connect port
 clair_db_port = 5432
-
 #Clair DB username
 clair_db_username = postgres
-
 #Clair default database
 clair_db = postgres
+
+#The interval of clair updaters, the unit is hour, set to 0 to disable the updaters.
+clair_updaters_interval = 12
 
 ##########End of Clair DB configuration############
 

--- a/make/prepare
+++ b/make/prepare
@@ -270,6 +270,7 @@ clair_db_host = rcp.get("configuration", "clair_db_host")
 clair_db_port = rcp.get("configuration", "clair_db_port")
 clair_db_username = rcp.get("configuration", "clair_db_username")
 clair_db = rcp.get("configuration", "clair_db")
+clair_updaters_interval = rcp.get("configuration", "clair_updaters_interval")
 
 uaa_endpoint = rcp.get("configuration", "uaa_endpoint")
 uaa_clientid = rcp.get("configuration", "uaa_clientid")
@@ -641,7 +642,8 @@ if args.clair_mode:
             username = clair_db_username,
             host = clair_db_host,
             port = clair_db_port,
-            dbname = clair_db)
+            dbname = clair_db,
+            interval = clair_updaters_interval)
 
 # config http proxy for Clair
     http_proxy = rcp.get("configuration", "http_proxy").strip()


### PR DESCRIPTION
To mitigate the impact we saw in the updater issues in clair, this
commit enable configuring the interval, include disabling the updaters
of clair.