### PR TITLE
Fix remove button not clickable

### DIFF
--- a/src/ui_ng/src/app/project/member/member.component.scss
+++ b/src/ui_ng/src/app/project/member/member.component.scss
@@ -26,6 +26,13 @@
 
 clr-datagrid {
     ::ng-deep clr-checkbox {
-        position: inherit;
-    }
+         position: inherit;
+     }
+ }
+
+ //This is for production build process.todo: Need to be removed, when production process refactored. 
+:host >>> clr-checkbox.checkbox.datagrid-foot-select {
+    position: inherit;
 }
+
+


### PR DESCRIPTION
Problem description:
In member tab, Action->remove is not clickable in production mode.

Root cause analysis:

Some style for clarity checkbox impact dropdown menu.

Fix:
We do a quick fix in member.component.scss. Set checkbox in this component
position:inherit;

This will overide the clarity original style