### PR TITLE
Update the icon used in Harbor chart

### DIFF
--- a/contrib/helm/harbor/Chart.yaml
+++ b/contrib/helm/harbor/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 - registry
 - harbor
 home: https://github.com/vmware/harbor
-icon: https://github.com/vmware/harbor/blob/master/docs/img/harbor_logo.png
+icon: https://raw.githubusercontent.com/vmware/harbor/master/docs/img/harbor_logo.png
 sources:
 - https://github.com/vmware/harbor/tree/master/contrib/helm/harbor
 maintainers:


### PR DESCRIPTION
This commit updates the URL of the icon used in Harbor helm chart