### PR TITLE
Set default creation_time and update_time at model

### DIFF
--- a/src/common/models/label.go
+++ b/src/common/models/label.go
@@ -31,8 +31,8 @@ type Label struct {
 	Level        string    `orm:"column(level)" json:"-"`
 	Scope        string    `orm:"column(scope)" json:"scope"`
 	ProjectID    int64     `orm:"column(project_id)" json:"project_id"`
-	CreationTime time.Time `orm:"column(creation_time)" json:"creation_time"`
-	UpdateTime   time.Time `orm:"column(update_time)" json:"update_time"`
+	CreationTime time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`
+	UpdateTime   time.Time `orm:"column(update_time);auto_now" json:"update_time"`
 	Deleted      bool      `orm:"column(deleted)" json:"deleted"`
 }
 
@@ -74,8 +74,8 @@ type ResourceLabel struct {
 	ResourceID   int64     `orm:"column(resource_id)"`
 	ResourceName string    `orm:"column(resource_name)"`
 	ResourceType string    `orm:"column(resource_type)"`
-	CreationTime time.Time `orm:"column(creation_time)"`
-	UpdateTime   time.Time `orm:"column(update_time)"`
+	CreationTime time.Time `orm:"column(creation_time);auto_now_add"`
+	UpdateTime   time.Time `orm:"column(update_time);auto_now"`
 }
 
 // TableName ...

--- a/src/common/models/pro_meta.go
+++ b/src/common/models/pro_meta.go
@@ -38,7 +38,7 @@ type ProjectMetadata struct {
 	ProjectID    int64     `orm:"column(project_id)" json:"project_id"`
 	Name         string    `orm:"column(name)" json:"name"`
 	Value        string    `orm:"column(value)" json:"value"`
-	CreationTime time.Time `orm:"column(creation_time)" json:"creation_time"`
-	UpdateTime   time.Time `orm:"column(update_time)" json:"update_time"`
+	CreationTime time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`
+	UpdateTime   time.Time `orm:"column(update_time);auto_now" json:"update_time"`
 	Deleted      bool      `orm:"column(deleted)" json:"deleted"`
 }

--- a/src/common/models/project.go
+++ b/src/common/models/project.go
@@ -27,8 +27,8 @@ type Project struct {
 	ProjectID    int64             `orm:"pk;auto;column(project_id)" json:"project_id"`
 	OwnerID      int               `orm:"column(owner_id)" json:"owner_id"`
 	Name         string            `orm:"column(name)" json:"name"`
-	CreationTime time.Time         `orm:"column(creation_time)" json:"creation_time"`
-	UpdateTime   time.Time         `orm:"column(update_time)" json:"update_time"`
+	CreationTime time.Time         `orm:"column(creation_time);auto_now_add" json:"creation_time"`
+	UpdateTime   time.Time         `orm:"column(update_time);auto_now" json:"update_time"`
 	Deleted      bool              `orm:"column(deleted)" json:"deleted"`
 	OwnerName    string            `orm:"-" json:"owner_name"`
 	Togglable    bool              `orm:"-" json:"togglable"`

--- a/src/common/models/user.go
+++ b/src/common/models/user.go
@@ -38,8 +38,8 @@ type User struct {
 	HasAdminRole bool         `orm:"column(sysadmin_flag)" json:"has_admin_role"`
 	ResetUUID    string       `orm:"column(reset_uuid)" json:"reset_uuid"`
 	Salt         string       `orm:"column(salt)" json:"-"`
-	CreationTime time.Time    `orm:"column(creation_time)" json:"creation_time"`
-	UpdateTime   time.Time    `orm:"column(update_time)" json:"update_time"`
+	CreationTime time.Time    `orm:"column(creation_time);auto_now_add" json:"creation_time"`
+	UpdateTime   time.Time    `orm:"column(update_time);auto_now" json:"update_time"`
 	GroupList    []*UserGroup `orm:"-" json:"-"`
 }
 

--- a/src/common/models/watch_item.go
+++ b/src/common/models/watch_item.go
@@ -25,8 +25,8 @@ type WatchItem struct {
 	Namespace    string    `orm:"column(namespace)" json:"namespace"`
 	OnDeletion   bool      `orm:"column(on_deletion)" json:"on_deletion"`
 	OnPush       bool      `orm:"column(on_push)" json:"on_push"`
-	CreationTime time.Time `orm:"column(creation_time)" json:"creation_time"`
-	UpdateTime   time.Time `orm:"column(update_time)" json:"update_time"`
+	CreationTime time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`
+	UpdateTime   time.Time `orm:"column(update_time);auto_now" json:"update_time"`
 }
 
 //TableName ...


### PR DESCRIPTION
This commit set the default value of creation_time and update_time to
data objects by adding `orm:add_now` annotations.