### PR TITLE
Update job status when failed to submit it

### DIFF
--- a/src/replication/replicator/replicator.go
+++ b/src/replication/replicator/replicator.go
@@ -119,6 +119,9 @@ func (d *DefaultReplicator) Replicate(replication *Replication) error {
 
 			uuid, err := d.client.SubmitJob(job)
 			if err != nil {
+				if er := dao.UpdateRepJobStatus(id, common_models.JobError); er != nil {
+					log.Errorf("failed to update the status of job %d: %s", id, er)
+				}
 				return err
 			}
 


### PR DESCRIPTION
Set the status of replication job to "error" when the submitting to jobservice fails