### PR TITLE
Fix access level can not sort

### DIFF
--- a/src/ui_ng/src/app/project/list-project/list-project.component.ts
+++ b/src/ui_ng/src/app/project/list-project/list-project.component.ts
@@ -58,7 +58,7 @@ export class ListProjectComponent implements OnDestroy {
     roleInfo = RoleInfo;
     repoCountComparator: Comparator<Project> = new CustomComparator<Project>("repo_count", "number");
     timeComparator: Comparator<Project> = new CustomComparator<Project>("creation_time", "date");
-    accessLevelComparator: Comparator<Project> = new CustomComparator<Project>("public", "number");
+    accessLevelComparator: Comparator<Project> = new CustomComparator<Project>("public", "string");
     roleComparator: Comparator<Project> = new CustomComparator<Project>("current_user_role_id", "number");
     currentPage = 1;
     totalCount = 0;

--- a/src/ui_ng/src/app/shared/shared.utils.ts
+++ b/src/ui_ng/src/app/shared/shared.utils.ts
@@ -143,14 +143,32 @@ export class CustomComparator<T> implements Comparator<T> {
     compare(a: { [key: string]: any | any[] }, b: { [key: string]: any | any[] }) {
         let comp = 0;
         if (a && b) {
-            let fieldA = a[this.fieldName];
-            let fieldB = b[this.fieldName];
+            let fieldA, fieldB;
+            for (let key of Object.keys(a)) {
+                if (key === this.fieldName) {
+                    fieldA = a[key];
+                    fieldB = b[key];
+                    break;
+                } else if (typeof a[key] === 'object') {
+                    let insideObject = a[key];
+                    for (let insideKey in insideObject) {
+                        if (insideKey === this.fieldName) {
+                            fieldA = insideObject[insideKey];
+                            fieldB = b[key][insideKey];
+                            break;
+                        }
+                    }
+                }
+            }
             switch (this.type) {
                 case "number":
                     comp = fieldB - fieldA;
                     break;
                 case "date":
                     comp = new Date(fieldB).getTime() - new Date(fieldA).getTime();
+                    break;
+                case "string":
+                    comp = fieldB.localeCompare(fieldA);
                     break;
             }
         }


### PR DESCRIPTION
Issue description:
In project list page. User click sort according access level, it does not work.

Fix:

Remodify the compare method.