### PR TITLE
Fix ldap cert verify has to align with ldap mode. should not show in …

### DIFF
--- a/src/ui_ng/src/app/config/auth/config-auth.component.html
+++ b/src/ui_ng/src/app/config/auth/config-auth.component.html
@@ -202,7 +202,7 @@
             </clr-checkbox>
         </div>
     </section>
-    <section>
+    <section *ngIf="showLdap">
         <div class="form-group">
             <label for="ldapVerifyCert">{{'CONFIG.LDAP.VERIFY_CERT' | translate}}</label>
             <clr-checkbox name="ldapVerifyCert" id="ldapVerifyCert" [clrChecked]="currentConfig.ldap_verify_cert.value" [clrDisabled]="disabled(currentConfig.ldap_scope)"

--- a/src/ui_ng/src/app/group/add-group-modal/add-group-modal.component.ts
+++ b/src/ui_ng/src/app/group/add-group-modal/add-group-modal.component.ts
@@ -95,7 +95,7 @@ export class AddGroupModalComponent implements OnInit, OnDestroy {
       .finally(() => this.close())
       .subscribe(
         res => {
-          this.msgHandler.showSuccess("ADD_GROUP_FAILURE");
+          this.msgHandler.showSuccess("GROUP.EDIT_GROUP_SUCCESS");
           this.dataChange.emit();
         },
         error => this.msgHandler.handleError(error)

--- a/src/ui_ng/src/i18n/lang/en-us-lang.json
+++ b/src/ui_ng/src/i18n/lang/en-us-lang.json
@@ -264,7 +264,7 @@
         "PROPERTY": "Property",
         "REG_TIME": "Registration Time",
         "ADD_GROUP_SUCCESS": "Add group success",
-        "ADD_GROUP_FAILURE": "Add group failure",
+        "EDIT_GROUP_SUCCESS": "Edit group success",
         "LDAP_TYPE": "LDAP"
     },
     "AUDIT_LOG": {

--- a/src/ui_ng/src/i18n/lang/es-es-lang.json
+++ b/src/ui_ng/src/i18n/lang/es-es-lang.json
@@ -263,7 +263,7 @@
         "PROPERTY": "Property",
         "REG_TIME": "Registration Time",
         "ADD_GROUP_SUCCESS": "Add group success",
-        "ADD_GROUP_FAILURE": "Add group failure",
+        "EDIT_GROUP_SUCCESS": "Edit group success",
         "LDAP_TYPE": "LDAP"
     },
     "AUDIT_LOG": {

--- a/src/ui_ng/src/i18n/lang/fr-fr-lang.json
+++ b/src/ui_ng/src/i18n/lang/fr-fr-lang.json
@@ -247,7 +247,7 @@
         "PROPERTY": "Property",
         "REG_TIME": "Registration Time",
         "ADD_GROUP_SUCCESS": "Add group success",
-        "ADD_GROUP_FAILURE": "Add group failure",
+        "EDIT_GROUP_SUCCESS": "Edit group success",
         "LDAP_TYPE": "LDAP"
     },
     "AUDIT_LOG": {

--- a/src/ui_ng/src/i18n/lang/zh-cn-lang.json
+++ b/src/ui_ng/src/i18n/lang/zh-cn-lang.json
@@ -263,7 +263,7 @@
         "GROUP_DN": "LDAP 组域",
         "REG_TIME": "注册时间",
         "ADD_GROUP_SUCCESS": "添加组成功",
-        "ADD_GROUP_FAILURE": "添加组失败",
+        "EDIT_GROUP_SUCCESS": "修改组成功",
         "LDAP_TYPE": "LDAP"
     },
     "AUDIT_LOG": {


### PR DESCRIPTION
…other mode.

Fix edit group sccess message.
This pr will focus on 2 issues:
1  In configuration,
LDAP verify cert should only show in ldap mode. It should not show in database mode.
2 When user using ldap mode to login harbor. And edit a group sccessfully, the popup message shows wrong. It should show "Edit group sccess".