### PR TITLE
Add secure go result into CI pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,16 @@ run_clarity_ut:
 	@echo "run clarity ut ..."
 	@$(DOCKERCMD) run --rm -v $(UINGPATH):$(CLARITYSEEDPATH) -v $(BUILDPATH)/tests:$(CLARITYSEEDPATH)/tests $(CLARITYIMAGE) $(SHELL) $(CLARITYSEEDPATH)/tests/run-clarity-ut.sh
 
+gosec:
+	#go get github.com/securego/gosec/cmd/gosec
+	#go get github.com/dghubble/sling
+	@echo "run secure go scan ..."
+	@if [ "$(GOSECRESULTS)" != "" ] ; then \
+		$(GOPATH)/bin/gosec -fmt=json -out=$(GOSECRESULTS) -quiet ./... | true ; \
+	else \
+		$(GOPATH)/bin/gosec -fmt=json -out=harbor_gas_output.json -quiet ./... | true ; \
+	fi
+
 pushimage:
 	@echo "pushing harbor images ..."
 	@$(DOCKERTAG) $(DOCKERIMAGENAME_ADMINSERVER):$(VERSIONTAG) $(REGISTRYSERVER)$(DOCKERIMAGENAME_ADMINSERVER):$(VERSIONTAG)

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -211,7 +211,17 @@ if [ $upload_latest_build == true ] && [ $upload_bundle_success == true ] && [ $
     uploader $latest_build_file $harbor_target_bucket  
 fi
 
-## ------------------------------------------------ Tear Down ---------------------------------------------------
+## --------------------------------------------- Upload securego results ------------------------------------------
+if [ $DRONE_BUILD_EVENT == "push" ] && [ $rc -eq 0 ]; then
+    go get github.com/securego/gosec/cmd/gosec
+    go get github.com/dghubble/sling
+    make gosec -e GOSECRESULTS=harbor-gosec-results-latest.json
+    echo $git_commit > ./harbor-gosec-results-latest-version
+    uploader harbor-gosec-results-latest.json $harbor_target_bucket
+    uploader harbor-gosec-results-latest-version $harbor_target_bucket
+fi
+
+## ------------------------------------------------ Tear Down -----------------------------------------------------
 if [ -f "$keyfile" ]; then
   rm -f $keyfile
 fi


### PR DESCRIPTION
This commit is to enable go secure scan in the CI pipeline, it happens at the phase of merging code. The results will be uploaded to /harbor-builds for master and /harbor-release for release-* named as harbor-gosec-results-latest.json