### PR TITLE
Add 'Deprecated' info for the chart

### DIFF
--- a/src/chartserver/chart_operator.go
+++ b/src/chartserver/chart_operator.go
@@ -47,6 +47,7 @@ type ChartInfo struct {
 	Created       time.Time
 	Icon          string
 	Home          string
+	Deprecated    bool
 }
 
 //ChartOperator is designed to process the contents of
@@ -129,6 +130,7 @@ func (cho *ChartOperator) GetChartList(content []byte) ([]*ChartInfo, error) {
 			chartInfo.Created = oVersion.Created
 			chartInfo.Home = lVersion.Home
 			chartInfo.Icon = lVersion.Icon
+			chartInfo.Deprecated = lVersion.Deprecated
 			chartList = append(chartList, chartInfo)
 		}
 	}

--- a/src/ui/api/chart_repository.go
+++ b/src/ui/api/chart_repository.go
@@ -296,19 +296,19 @@ func (cra *ChartRepositoryAPI) requireAccess(namespace string, accessLevel uint)
 	//Should be system admin role
 	case accessLevelSystem:
 		if !cra.SecurityCtx.IsSysAdmin() {
-			err = fmt.Errorf("system admin role is required but user '%s' is not", cra.SecurityCtx.GetUsername())
+			err = errors.New("permission denied: system admin role is required")
 		}
 	case accessLevelAll:
 		if !cra.SecurityCtx.HasAllPerm(namespace) {
-			err = fmt.Errorf("project admin role is required but user '%s' does not have", cra.SecurityCtx.GetUsername())
+			err = errors.New("permission denied: project admin or higher role is required")
 		}
 	case accessLevelWrite:
 		if !cra.SecurityCtx.HasWritePerm(namespace) {
-			err = fmt.Errorf("developer role is required but user '%s' does not have", cra.SecurityCtx.GetUsername())
+			err = errors.New("permission denied: developer or higher role is required")
 		}
 	case accessLevelRead:
 		if !cra.SecurityCtx.HasReadPerm(namespace) {
-			err = fmt.Errorf("at least a guest role is required for user '%s'", cra.SecurityCtx.GetUsername())
+			err = errors.New("permission denied: guest or higher role is required")
 		}
 	default:
 		//access rejected for invalid scope


### PR DESCRIPTION
**Add 'Deprecated' info for the chart**

- info returned by getting /charts include 'Deprecated' field
- amend error message in the access checking logic