### PR TITLE
Fix helm chart getImageLink was deleted by accident

### DIFF
--- a/src/ui_ng/lib/src/helm-chart/versions/helm-chart-version.component.ts
+++ b/src/ui_ng/lib/src/helm-chart/versions/helm-chart-version.component.ts
@@ -290,6 +290,14 @@ export class ChartVersionComponent implements OnInit {
     }
   }
 
+  getImgLink(v: HelmChartVersion) {
+    if (v.icon) {
+      return v.icon;
+    } else {
+      return DefaultHelmIcon;
+    }
+  }
+
 
   getDefaultIcon(v: HelmChartVersion) {
     v.icon = this.chartDefaultIcon;

--- a/src/ui_ng/src/app/shared/shared.utils.ts
+++ b/src/ui_ng/src/app/shared/shared.utils.ts
@@ -26,12 +26,10 @@ import { httpStatusCode, AlertType } from './shared.const';
  * @returns {string}
  */
 export const errorHandler = function (error: any): string {
-    if (!error) {
-        return "UNKNOWN_ERROR";
-    }
-    if (!(error.statusCode || error.status)) {
+    let errorObj = error.json();
+    if (errorObj && errorObj.error) {
         // treat as string message
-        return '' + error;
+        return errorObj.error;
     } else {
         switch (error.statusCode || error.status) {
             case 400:


### PR DESCRIPTION
add back getImageLink function

fix issue:upload helm chart can not show backend message. 