### PR TITLE
Remove the tdnf error eater in docker files

### DIFF
--- a/make/photon/registryctl/Dockerfile
+++ b/make/photon/registryctl/Dockerfile
@@ -2,7 +2,7 @@ FROM photon:1.0
 
 MAINTAINER wangyan@vmware.com
 
-RUN tdnf distro-sync -y || echo \
+RUN tdnf distro-sync -y \
     && tdnf erase vim -y \
     && tdnf install sudo -y >> /dev/null\
     && tdnf clean all \

--- a/tools/migration/Dockerfile
+++ b/tools/migration/Dockerfile
@@ -3,7 +3,7 @@ FROM photon:1.0
 ENV PGDATA /var/lib/postgresql/data
 
 ## have both mysql and pgsql installed.
-RUN tdnf distro-sync -y || echo \
+RUN tdnf distro-sync -y \
     && tdnf install -y sed shadow procps-ng gawk gzip sudo net-tools >> /dev/null\
     && groupadd -r -g 10000 mysql && useradd --no-log-init -r -g 10000 -u 10000 mysql \
     && tdnf install -y mariadb-server mariadb mariadb-devel python2 python2-devel python-pip gcc \


### PR DESCRIPTION
The "|| echo" is the workaround to handle the tdnf install error, it's used for debug only.